### PR TITLE
대쉬보드 추가 & 이전 커밋들에서 자잘한 사항들 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "dependencies": {
     "@tanstack/react-query": "^4.24.6",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,24 @@
 import React from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+import DashboardNav from './components/DashboardNav';
+
 import MainBottomSection from './components/MainBottomSection';
 import MainMiddleSection from './components/MainMiddleSection';
 import MainNav from './components/MainNav';
 import MainTopSection from './components/MainTopSection';
 
 function App() {
+  const location = useLocation();
+
+  if (location.pathname !== '/') {
+    return (
+      <>
+        <DashboardNav />
+        <Outlet />
+      </>
+    );
+  }
+
   return (
     <>
       <MainNav />

--- a/src/components/DashboardNav.jsx
+++ b/src/components/DashboardNav.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+import navLogo from '../assets/nav-logo.png';
+
+export default function DashboardNav() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleLogoClick = () => {
+    navigate('/dashboard');
+  };
+
+  const handleLogoutClick = () => {
+    console.log('로그아웃 실행');
+  };
+  return (
+    <Nav>
+      <LeftContainer>
+        <NavLogo src={navLogo} onClick={handleLogoClick} />
+        <NavItem
+          inputColor={location.pathname === '/emails' ? 'black' : null}
+          onClick={() => navigate('/emails')}
+        >
+          이메일
+        </NavItem>
+        <NavItem
+          inputColor={location.pathname === '/subscribers' ? 'black' : null}
+          onClick={() => navigate('/subscribers')}
+        >
+          구독자
+        </NavItem>
+        <NavItem
+          inputColor={location.pathname === '/sender' ? 'black' : null}
+          onClick={() => navigate('/sender')}
+        >
+          발신자
+        </NavItem>
+      </LeftContainer>
+      <Logout onClick={handleLogoutClick}>로그아웃</Logout>
+    </Nav>
+  );
+}
+
+const Nav = styled.nav`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 19px 34px;
+  border-bottom: 1px solid #dfe0e4;
+`;
+
+const LeftContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const NavLogo = styled.img`
+  width: 120px;
+  height: 34px;
+  margin-right: 10px;
+  cursor: pointer;
+`;
+
+const NavItem = styled.span`
+  margin-left: 20px;
+  padding: 0px 10px;
+  font-size: 14px;
+  font-weight: 400;
+  color: ${props => props.inputColor || '#dfe0e4'};
+  cursor: pointer;
+
+  &:hover {
+    color: #ffdf2b;
+  }
+`;
+
+const Logout = styled.button`
+  padding: 10px 14px;
+  border-radius: 5px;
+  background-color: #ffdf2b;
+`;

--- a/src/components/DashboardNav.jsx
+++ b/src/components/DashboardNav.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import navLogo from '../assets/nav-logo.png';
 
 export default function DashboardNav() {
-  const navigate = useNavigate();
   const location = useLocation();
-
-  const handleLogoClick = () => {
-    navigate('/dashboard');
-  };
 
   const handleLogoutClick = () => {
     console.log('로그아웃 실행');
@@ -18,25 +13,30 @@ export default function DashboardNav() {
   return (
     <Nav>
       <LeftContainer>
-        <NavLogo src={navLogo} onClick={handleLogoClick} />
-        <NavItem
-          inputColor={location.pathname === '/emails' ? 'black' : null}
-          onClick={() => navigate('/emails')}
-        >
-          이메일
-        </NavItem>
-        <NavItem
-          inputColor={location.pathname === '/subscribers' ? 'black' : null}
-          onClick={() => navigate('/subscribers')}
-        >
-          구독자
-        </NavItem>
-        <NavItem
-          inputColor={location.pathname === '/sender' ? 'black' : null}
-          onClick={() => navigate('/sender')}
-        >
-          발신자
-        </NavItem>
+        <Link to="/dashboard">
+          <NavLogo src={navLogo} />
+        </Link>
+        <Link to="/emails">
+          <NavItem
+            inputColor={location.pathname === '/emails' ? 'black' : null}
+          >
+            이메일
+          </NavItem>
+        </Link>
+        <Link to="/subscribers">
+          <NavItem
+            inputColor={location.pathname === '/subscribers' ? 'black' : null}
+          >
+            구독자
+          </NavItem>
+        </Link>
+        <Link to="/sender">
+          <NavItem
+            inputColor={location.pathname === '/sender' ? 'black' : null}
+          >
+            발신자
+          </NavItem>
+        </Link>
       </LeftContainer>
       <Logout onClick={handleLogoutClick}>로그아웃</Logout>
     </Nav>

--- a/src/components/MainBottomSection.jsx
+++ b/src/components/MainBottomSection.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 export default function MainBottomSection() {
   return (
     <Section>
       <Title>지금 바로 시작해보세요</Title>
-      <StartNow href="/sign-up">지금 시작하기</StartNow>
+      <Link to="/sign-up">
+        <StartNow>지금 시작하기</StartNow>
+      </Link>
     </Section>
   );
 }
@@ -20,7 +23,7 @@ const Title = styled.h1`
   padding-bottom: 40px;
 `;
 
-const StartNow = styled.a`
+const StartNow = styled.span`
   padding: 12px 16px;
   border-radius: 5px;
   background-color: black;

--- a/src/components/MainNav.jsx
+++ b/src/components/MainNav.jsx
@@ -1,19 +1,25 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import navLogo from '../assets/nav-logo.png';
 
 export default function MainNav() {
+  const handleLogoClick = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
   return (
     <Nav>
       <div>
-        <a href="/">
-          <Img src={navLogo} alt="nav-logo" />
-        </a>
+        <Img src={navLogo} alt="nav-logo" onClick={handleLogoClick} />
       </div>
       <div>
-        <Login href="/login">로그인</Login>
-        <SignUp href="/sign-up">회원가입</SignUp>
+        <Link to="/login">
+          <Login>로그인</Login>
+        </Link>
+        <Link to="/sign-up">
+          <SignUp>회원가입</SignUp>
+        </Link>
       </div>
     </Nav>
   );
@@ -33,13 +39,14 @@ const Nav = styled.nav`
 const Img = styled.img`
   width: 120px;
   height: 34px;
+  cursor: pointer;
 `;
 
-const Login = styled.a`
+const Login = styled.span`
   padding: 10px 14px;
 `;
 
-const SignUp = styled.a`
+const SignUp = styled.span`
   padding: 10px 14px;
   border-radius: 5px;
   background-color: #ffdf2b;

--- a/src/components/MainTopSection.jsx
+++ b/src/components/MainTopSection.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import mailWoman from '../assets/main-mail-woman.png';
@@ -18,7 +19,9 @@ export default function MainTopSection() {
             <br />
             ez-mail 로 누구나 쉽게 뉴스레터를 발행할 수 있습니다.
           </Description>
-          <StartNow href="/sign-up">지금 시작하기</StartNow>
+          <Link to="/sign-up">
+            <StartNow>지금 시작하기</StartNow>
+          </Link>
         </InnerText>
         <MailWoman src={mailWoman} alt="mail-woman" />
       </Inner>
@@ -51,7 +54,7 @@ const MailWoman = styled.img`
   height: 370px;
 `;
 
-const StartNow = styled.a`
+const StartNow = styled.span`
   padding: 12px 16px;
   border-radius: 5px;
   background-color: #ffdf2b;

--- a/src/pages/DashBoard.jsx
+++ b/src/pages/DashBoard.jsx
@@ -1,5 +1,169 @@
 import React from 'react';
+import styled from 'styled-components';
+import {
+  getOpenMailPercentage,
+  getRefinedTrendData,
+  getSuccessPercentage,
+} from '../utils/dashboard';
+
+// 임시 데이터
+const emailData = {
+  _id: '12315',
+  editingStep: 4,
+  emailTitle: '테스트 제목',
+  emailContent: '<h1>테스트 이메일 입니다<h1>',
+  sender: '홍길동',
+  emailPreviewText: '테스트 이메일 미리보기',
+  recipients: [
+    {
+      email: 'asdf@asdf.com',
+      name: '길홍동',
+      adAgreement: true,
+      isEmailOpen: false,
+    },
+    {
+      email: 'zxcv@asdf.com',
+      name: '홍길',
+      adAgreement: true,
+      isEmailOpen: true,
+    },
+    {
+      email: 'qwer@asdf.com',
+      name: '동길',
+      adAgreement: true,
+      isEmailOpen: true,
+    },
+  ],
+  totalSendCount: 3,
+  successSendCount: 3,
+  startSendDate: new Date(`2023/02/13`),
+  endSendDate: new Date('2023/02/14'),
+};
+const trendData = [1, 4, 2, 33, 60, 0, 1];
 
 export default function DashBoard() {
-  return <div>dashboard</div>;
+  const subscriberTrendList = getRefinedTrendData(trendData).map(item => {
+    return (
+      <Li
+        key={item[2] + item[1]}
+        count={item[0]}
+        height={item[1]}
+        date={item[2]}
+      />
+    );
+  });
+
+  return (
+    <Section>
+      <MainContainer>
+        <Title>대시보드</Title>
+        <SmallTitle>최근 발송한 이메일</SmallTitle>
+        <PercentInfoBox>
+          <LeftPercentBox>
+            <PercentTitleText>발송성공</PercentTitleText>
+            <PercentNumberText>
+              {getSuccessPercentage(emailData)}
+            </PercentNumberText>
+          </LeftPercentBox>
+          <RightPercentBox>
+            <PercentTitleText>오픈</PercentTitleText>
+            <PercentNumberText inputColor="#ffdf2b">
+              {getOpenMailPercentage(emailData)}
+            </PercentNumberText>
+          </RightPercentBox>
+        </PercentInfoBox>
+        <SmallTitle>구독자</SmallTitle>
+        <Ul>{subscriberTrendList}</Ul>
+      </MainContainer>
+    </Section>
+  );
 }
+
+const Section = styled.section``;
+
+const MainContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1000px;
+  height: 760px;
+  margin: auto;
+`;
+
+const Title = styled.span`
+  padding: 38px 0;
+  font-size: 28px;
+  font-weight: 500;
+`;
+
+const SmallTitle = styled.span`
+  padding-top: 20px;
+  padding-bottom: 32px;
+  font-size: 24px;
+  font-weight: 500;
+`;
+
+const PercentInfoBox = styled.div`
+  display: flex;
+  width: 450px;
+  height: 150px;
+  margin-bottom: 30px;
+`;
+
+const LeftPercentBox = styled.div`
+  width: 50%;
+  border: 1px solid #b5acac;
+`;
+
+const PercentTitleText = styled.div`
+  padding: 16px;
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+const PercentNumberText = styled.div`
+  padding-top: 4px;
+  color: ${props => props.inputColor || 'black'};
+  font-size: 50px;
+  text-align: center;
+`;
+
+const RightPercentBox = styled.div`
+  width: 50%;
+  border: 1px solid #b5acac;
+  border-width: 1px 1px 1px 0px;
+`;
+
+const Ul = styled.ul`
+  display: flex;
+  justify-content: space-evenly;
+  align-items: flex-end;
+  width: 100%;
+  height: 260px;
+  margin-bottom: 100px;
+  border: 1px solid #b5acac;
+`;
+
+const Li = styled.li`
+  width: 30px;
+  height: ${props => props.height}%;
+  background-color: #ffdf2b;
+
+  &:before {
+    position: relative;
+    top: -30px;
+    display: block;
+    text-align: center;
+    font-weight: 400;
+    content: '${props => props.count}';
+  }
+
+  &:after {
+    position: relative;
+    display: block;
+    top: 100%;
+    left: -14px;
+    width: 100px;
+    font-weight: 400;
+    content: '${props => props.date}';
+  }
+`;

--- a/src/pages/Emails.jsx
+++ b/src/pages/Emails.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Emails() {
+  return <div>이메일 리스트</div>;
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import logo from '../assets/login-logo.png';
@@ -8,7 +8,6 @@ import LoginInput from '../components/LoginInput';
 
 export default function Login() {
   const [userInput, setUserInput] = useState({ email: '', password: '' });
-  const navigate = useNavigate();
 
   const handleUserInput = e => {
     setUserInput({
@@ -19,13 +18,12 @@ export default function Login() {
   const handleLoginClick = () => {
     // 로그인 api 요청
   };
-  const handleLogoClick = () => {
-    navigate('/');
-  };
 
   return (
     <LoginContainer>
-      <Logo src={logo} alt="login-logo" onClick={handleLogoClick} />
+      <Link to="/">
+        <Logo src={logo} alt="login-logo" />
+      </Link>
       <Hello>또 오셨군요 반가워요!</Hello>
       <LoginInput
         id="email"
@@ -42,8 +40,12 @@ export default function Login() {
         비밀번호
       </LoginInput>
       <LoginButton onClick={handleLoginClick}>로그인</LoginButton>
-      <NeedSignUp href="/sign-up">계정이 없으신가요?</NeedSignUp>
-      <BottomLogo src={bottomLogo} onClick={handleLogoClick} />
+      <Link to="/sign-up">
+        <NeedSignUp>계정이 없으신가요?</NeedSignUp>
+      </Link>
+      <Link to="/">
+        <BottomLogo src={bottomLogo} />
+      </Link>
     </LoginContainer>
   );
 }
@@ -59,13 +61,13 @@ const LoginContainer = styled.div`
 const Logo = styled.img`
   width: 80px;
   height: 80px;
-  margin-top: 100px;
+  margin-top: 60px;
   margin-bottom: 40px;
   cursor: pointer;
 `;
 
 const Hello = styled.span`
-  padding-bottom: 80px;
+  padding-bottom: 60px;
   font-size: 24px;
   font-weight: 500;
 `;
@@ -79,14 +81,16 @@ const LoginButton = styled.button`
   font-weight: 500;
 `;
 
-const NeedSignUp = styled.a`
+const NeedSignUp = styled.span`
+  display: inline-block;
   padding-top: 20px;
   color: #3e81f6;
+  cursor: pointer;
 `;
 
 const BottomLogo = styled.img`
   width: 120px;
   height: 34px;
-  margin-top: 150px;
+  margin-top: 60px;
   cursor: pointer;
 `;

--- a/src/pages/SIgnUp.jsx
+++ b/src/pages/SIgnUp.jsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import logo from '../assets/login-logo.png';
-import bottomLogo from '../assets/nav-logo.png';
 import SignUpInput from '../components/LoginInput';
 
 export default function SignUp() {
@@ -12,7 +11,6 @@ export default function SignUp() {
     name: '',
     password: '',
   });
-  const navigate = useNavigate();
 
   const handleUserInput = e => {
     setUserInput({
@@ -24,13 +22,11 @@ export default function SignUp() {
     // 회원가입 api 요청
   };
 
-  const handleLogoClick = () => {
-    navigate('/');
-  };
-
   return (
     <SignUpContainer>
-      <Logo src={logo} alt="login-logo" onClick={handleLogoClick} />
+      <Link to="/">
+        <Logo src={logo} alt="login-logo" />
+      </Link>
       <Hello>환영해요!</Hello>
       <SignUpInput
         id="email"
@@ -54,8 +50,9 @@ export default function SignUp() {
         비밀번호
       </SignUpInput>
       <LoginButton onClick={handleSignUpClick}>회원가입</LoginButton>
-      <NeedLogin href="/login">이미 가입 하셨나요?</NeedLogin>
-      <BottomLogo src={bottomLogo} onClick={handleLogoClick} />
+      <Link to="/login">
+        <NeedLogin>이미 가입 하셨나요?</NeedLogin>
+      </Link>
     </SignUpContainer>
   );
 }
@@ -71,13 +68,13 @@ const SignUpContainer = styled.div`
 const Logo = styled.img`
   width: 80px;
   height: 80px;
-  margin-top: 100px;
+  margin-top: 60px;
   margin-bottom: 40px;
   cursor: pointer;
 `;
 
 const Hello = styled.span`
-  padding-bottom: 80px;
+  padding-bottom: 60px;
   font-size: 24px;
   font-weight: 500;
 `;
@@ -91,14 +88,9 @@ const LoginButton = styled.button`
   font-weight: 500;
 `;
 
-const NeedLogin = styled.a`
+const NeedLogin = styled.span`
+  display: inline-block;
   padding-top: 20px;
   color: #3e81f6;
-`;
-
-const BottomLogo = styled.img`
-  width: 120px;
-  height: 34px;
-  margin-top: 38px;
   cursor: pointer;
 `;

--- a/src/pages/Sender.jsx
+++ b/src/pages/Sender.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Sender() {
+  return <div>발신자</div>;
+}

--- a/src/pages/Subscribers.jsx
+++ b/src/pages/Subscribers.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Subscribers() {
+  return <div>구독자</div>;
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -4,13 +4,35 @@ import App from '../App';
 import DashBoard from '../pages/DashBoard';
 import Login from '../pages/Login';
 import NotFound from '../pages/NotFound';
+import Sender from '../pages/Sender';
 import SignUp from '../pages/SIgnUp';
+import Emails from '../pages/Emails';
+import Subscribers from '../pages/Subscribers';
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <App />,
     errorElement: <NotFound />,
+    children: [
+      {
+        index: true,
+        path: '/dashboard',
+        element: <DashBoard />,
+      },
+      {
+        path: '/emails',
+        element: <Emails />,
+      },
+      {
+        path: '/subscribers',
+        element: <Subscribers />,
+      },
+      {
+        path: '/sender',
+        element: <Sender />,
+      },
+    ],
   },
   {
     path: '/login',
@@ -19,10 +41,6 @@ const router = createBrowserRouter([
   {
     path: '/sign-up',
     element: <SignUp />,
-  },
-  {
-    path: '/dashboard',
-    element: <DashBoard />,
   },
 ]);
 

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -1,0 +1,47 @@
+function getPercentHeight(val, max) {
+  const LIMITED_HEIGHT = 80;
+
+  if (max === 0) return '0';
+
+  return `${(val / max) * LIMITED_HEIGHT}`;
+}
+
+function getDateString(parseDate) {
+  const month = new Date(parseDate).getMonth() + 1;
+  const date = new Date(parseDate).getDate();
+
+  return `${month}월 ${date}일`;
+}
+
+export function getRefinedTrendData(data) {
+  const today = Date.now();
+  const max = Math.max(...data);
+  const DAY = 86400000;
+  const refinedData = data.map((item, index) => {
+    return [
+      String(item),
+      getPercentHeight(item, max),
+      getDateString(today - DAY * index),
+    ];
+  });
+
+  return refinedData;
+}
+
+export function getSuccessPercentage(data) {
+  const { totalSendCount, successSendCount } = data;
+
+  return `${(successSendCount / totalSendCount) * 100}%`;
+}
+
+export function getOpenMailPercentage(data) {
+  const totalCount = data.recipients.length;
+
+  if (totalCount === 0) return '0%';
+
+  const openCount = data.recipients.filter(
+    recipient => recipient.isEmailOpen,
+  ).length;
+
+  return `${Math.floor((openCount / totalCount) * 100)}%`;
+}


### PR DESCRIPTION
## 주요 구현 사항
1. 로그인 후 뜨는 대쉬보드 기본 레이아웃과 백엔드에서 받아오는 데이터를 정제하는 로직을 추가했습니다.
2. 이전 커밋들에서 a 태그를 썼던 부분들을 라우터를 이용할 수 있도록 <Link> 로 모두 수정하였습니다.
3. 로그인 후 뜨는 기본 레이아웃들이 nav 바를 공유할 수 있도록 하였고, 이메일, 구독자, 발신자 기본 페이지들 파일도 
생성해뒀습니다.
4. useNavigate 를 사용했던 로직들도 전부 <Link> 를 사용하는 것으로 수정했습니다.
    
## 구현 필요 사항
1. 아직 리코일과 리액트 쿼리 도입 전이라 로그인을 감지하는 기능과 백엔드에서 정보를 받아오는 기능은 추가 전입니다.

## 까다로웠던 것들
1. 그래프에서 숫자와 날짜가 그래프 정중앙에 뜨도록 하는데 시간이 좀 걸렸습니다. 가상선택자와 블록 설정 변경을 통해 해결했습니다.