### PR TITLE
이메일 생성 1단계 페이지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,26 @@
 import React from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useParams } from 'react-router-dom';
 import DashboardNav from './components/DashboardNav';
 
 import MainBottomSection from './components/MainBottomSection';
 import MainMiddleSection from './components/MainMiddleSection';
 import MainNav from './components/MainNav';
+import EmailEditingNav from './components/EmailEditingNav';
 import MainTopSection from './components/MainTopSection';
 
 function App() {
   const location = useLocation();
-
+  const params = useParams();
   if (location.pathname !== '/') {
+    if (location.pathname.includes(`/emails/${params.email_id}/step`)) {
+      return (
+        <>
+          <EmailEditingNav />
+          <Outlet />
+        </>
+      );
+    }
+
     return (
       <>
         <DashboardNav />

--- a/src/components/EmailEditingNav.jsx
+++ b/src/components/EmailEditingNav.jsx
@@ -6,7 +6,9 @@ import { useNavigate } from 'react-router-dom';
 
 export default function EmailEditingNav() {
   const navigate = useNavigate();
+
   const emailTitle = '제목없음';
+
   const handleSendButtonClick = () => {
     console.log('메일 발송');
   };

--- a/src/components/EmailEditingNav.jsx
+++ b/src/components/EmailEditingNav.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
+import { useNavigate } from 'react-router-dom';
+
+export default function EmailEditingNav() {
+  const navigate = useNavigate();
+  const emailTitle = '제목없음';
+  const handleSendButtonClick = () => {
+    console.log('메일 발송');
+  };
+
+  const handlePrevButtonClick = () => {
+    navigate(-1);
+  };
+
+  return (
+    <>
+      <Nav>
+        <Prev onClick={handlePrevButtonClick}>
+          <StyledFaAngleLeft icon={faAngleLeft} />
+        </Prev>
+        <EmailTitle>{emailTitle}</EmailTitle>
+        <Send onClick={handleSendButtonClick}>발송하기</Send>
+      </Nav>
+      <SubNav>
+        <Step>구독자</Step>
+        <StyledFaAngleRight icon={faAngleRight} />
+        <Step>발송정보</Step>
+        <StyledFaAngleRight icon={faAngleRight} />
+        <Step>콘텐츠</Step>
+      </SubNav>
+    </>
+  );
+}
+
+const Nav = styled.nav`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 76.5px;
+  border-bottom: 1px solid #dfe0e4;
+`;
+
+const Prev = styled.button`
+  height: 100%;
+  margin-right: 20px;
+  padding: 0 20px;
+  background-color: #ffdf2b;
+`;
+
+const EmailTitle = styled.span`
+  font-size: 20px;
+  font-weight: 600;
+  flex: 1;
+`;
+
+const Send = styled.button`
+  margin-right: 34px;
+  padding: 10px 14px;
+  border-radius: 5px;
+  background-color: #ffdf2b;
+`;
+
+const StyledFaAngleLeft = styled(FontAwesomeIcon)`
+  font-size: 30px;
+`;
+
+const SubNav = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 50px;
+  border-bottom: 1px solid #dfe0e4;
+  text-align: center;
+  color: #bdbdbd;
+`;
+
+const Step = styled.span`
+  flex: 2;
+  &:nth-child(1) {
+    font-weight: 500;
+    color: black;
+  }
+`;
+
+const StyledFaAngleRight = styled(FontAwesomeIcon)`
+  font-size: 20px;
+  flex: 0.5;
+`;

--- a/src/pages/emails/EmailEditingStep01.jsx
+++ b/src/pages/emails/EmailEditingStep01.jsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export default function EmailEditingStep01() {
+  const subscribersData = [
+    {
+      _id: '12315',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: true,
+    },
+    {
+      _id: '123151',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: true,
+    },
+    {
+      _id: '123152',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: false,
+    },
+    {
+      _id: '123153',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: false,
+    },
+    {
+      _id: '123154',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: false,
+    },
+    {
+      _id: '123155',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: false,
+    },
+    {
+      _id: '123156',
+      email: 'abcd112342345@test.com',
+      name: '김개똥',
+      adAgreement: false,
+    },
+    {
+      _id: '123157',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: true,
+    },
+    {
+      _id: '123158',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: false,
+    },
+    {
+      _id: '123159',
+      email: 'abcd@test.com',
+      name: '김개똥',
+      adAgreement: false,
+    },
+  ];
+
+  const tableHead = (
+    <tr>
+      <td>
+        <input type="checkbox" />
+      </td>
+      <td>이메일주소</td>
+      <td>이름</td>
+      <td>광고성 정보 수신 동의</td>
+    </tr>
+  );
+
+  const subscribers = subscribersData.map(item => {
+    return (
+      <tr>
+        <td>
+          <input type="checkbox" />
+        </td>
+        <td>{item.email}</td>
+        <td>{item.name}</td>
+        <td>{item.adAgreement ? '동의' : '거부'}</td>
+      </tr>
+    );
+  });
+
+  return (
+    <>
+      <section>
+        <MainContainer>
+          <Title>구독자를 선택하세요</Title>
+          <SubscriberTable>
+            <table>
+              <thead>{tableHead}</thead>
+              <tbody>{subscribers}</tbody>
+            </table>
+          </SubscriberTable>
+        </MainContainer>
+      </section>
+      <BottomButtons>
+        <BottomButton>이전</BottomButton>
+        <BottomButton>다음</BottomButton>
+      </BottomButtons>
+    </>
+  );
+}
+
+const MainContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1000px;
+  margin: auto;
+`;
+
+const Title = styled.span`
+  padding: 38px 0;
+  margin-bottom: 50px;
+  font-size: 28px;
+  font-weight: 500;
+`;
+
+const BottomButtons = styled.div`
+  display: flex;
+  position: fixed;
+  bottom: 0px;
+  width: 100%;
+  text-align: center;
+`;
+
+const SubscriberTable = styled.div`
+  overflow: auto;
+  height: 300px;
+  table {
+    width: 100%;
+    thead {
+      position: sticky;
+      top: 0;
+      background-color: #f5f5f5;
+      tr {
+        padding: 30px 0;
+        border-top: 2px solid #b5acac;
+        &:last-child {
+          border-bottom: 2px solid #b5acac;
+        }
+      }
+      td {
+        padding: 16px 0;
+        text-align: center;
+        &:nth-child(1) {
+          width: 7%;
+        }
+        &:nth-child(2) {
+          width: 15%;
+        }
+        &:nth-child(3) {
+          width: 15%;
+        }
+        &:nth-child(4) {
+          padding: 0 400px 0 0;
+          width: 60%;
+        }
+      }
+    }
+    tbody {
+      tr {
+        padding: 30px 0;
+        border-top: 2px solid #b5acac;
+        &:last-child {
+          border-bottom: 2px solid #b5acac;
+        }
+      }
+      td {
+        padding: 10px 0;
+        text-align: center;
+        &:nth-child(1) {
+          width: 7%;
+        }
+        &:nth-child(2) {
+          width: 15%;
+        }
+        &:nth-child(3) {
+          width: 15%;
+        }
+        &:nth-child(4) {
+          padding: 0 400px 0 0;
+          width: 60%;
+        }
+      }
+    }
+  }
+  input {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+`;
+
+const BottomButton = styled.div`
+  width: 50%;
+  padding: 10px 0;
+  font-size: 20px;
+  border: 1px solid #dfe0e4;
+  background-color: #f5f5f5;
+  cursor: pointer;
+  &:nth-child(1) {
+    color: #bdbdbd;
+    cursor: default;
+  }
+`;

--- a/src/pages/emails/EmailEditingStep02.jsx
+++ b/src/pages/emails/EmailEditingStep02.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function EmailEditingStep02() {
+  return <div>스텝2</div>;
+}

--- a/src/pages/emails/EmailEditingStep03.jsx
+++ b/src/pages/emails/EmailEditingStep03.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function EmailEditingStep03() {
+  return <div>스텝3</div>;
+}

--- a/src/pages/emails/EmailEditingStep04.jsx
+++ b/src/pages/emails/EmailEditingStep04.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function EmailEditingStep04() {
+  return <div>스텝4</div>;
+}

--- a/src/pages/emails/Emails.jsx
+++ b/src/pages/emails/Emails.jsx
@@ -59,11 +59,7 @@ export default function Emails() {
   const handleNewEmailButtonClick = () => {
     console.log('이메일 생성 api 실행');
     const emailId = 'test';
-    navigate(`/emails/${emailId}/step01`, {
-      state: {
-        emailId,
-      },
-    });
+    navigate(`/emails/${emailId}/step01`);
   };
 
   const emailTemplatesList = emailTemplatesData

--- a/src/pages/emails/Emails.jsx
+++ b/src/pages/emails/Emails.jsx
@@ -7,6 +7,7 @@ import {
   faPencil,
 } from '@fortawesome/free-solid-svg-icons';
 import { faCheckCircle } from '@fortawesome/free-regular-svg-icons';
+import { useNavigate } from 'react-router-dom';
 
 const emailTemplatesData = [
   {
@@ -54,8 +55,15 @@ const emailTemplatesData = [
 ];
 
 export default function Emails() {
+  const navigate = useNavigate();
   const handleNewEmailButtonClick = () => {
-    console.log('이메일 생성');
+    console.log('이메일 생성 api 실행');
+    const emailId = 'test';
+    navigate(`/emails/${emailId}/step01`, {
+      state: {
+        emailId,
+      },
+    });
   };
 
   const emailTemplatesList = emailTemplatesData

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -6,7 +6,11 @@ import Login from '../pages/Login';
 import NotFound from '../pages/NotFound';
 import Sender from '../pages/Sender';
 import SignUp from '../pages/SIgnUp';
-import Emails from '../pages/Emails';
+import Emails from '../pages/emails/Emails';
+import Step01 from '../pages/emails/EmailEditingStep01';
+import Step02 from '../pages/emails/EmailEditingStep02';
+import Step03 from '../pages/emails/EmailEditingStep03';
+import Step04 from '../pages/emails/EmailEditingStep04';
 import Subscribers from '../pages/Subscribers';
 
 const router = createBrowserRouter([
@@ -32,6 +36,22 @@ const router = createBrowserRouter([
         path: '/sender',
         element: <Sender />,
       },
+      {
+        path: '/emails/:email_id/step01',
+        element: <Step01 />,
+      },
+      {
+        path: '/emails/:email_id/step02',
+        element: <Step02 />,
+      },
+      {
+        path: '/emails/:email_id/step03',
+        element: <Step03 />,
+      },
+      {
+        path: '/emails/:email_id/step04',
+        element: <Step04 />,
+      },
     ],
   },
   {
@@ -42,6 +62,50 @@ const router = createBrowserRouter([
     path: '/sign-up',
     element: <SignUp />,
   },
+  // {
+  //   path: '/emails/:email_id',
+  //   element: <Step01 />,
+  // },
+  // {
+  //   path: '/emails',
+  //   element: <Emails />,
+  //   errorElement: <NotFound />,
+  //   children: [
+  //     {
+  //       index: true,
+  //       path: '/emails/:email_id/step01',
+  //       element: <Step01 />,
+  //     },
+  //     {
+  //       path: '/emails/:email_id/step02',
+  //       element: <Step02 />,
+  //     },
+  //     {
+  //       path: '/emails/:email_id/step03',
+  //       element: <Step03 />,
+  //     },
+  //     {
+  //       path: '/emails/:email_id/step04',
+  //       element: <Step04 />,
+  //     },
+  //   ],
+  // },
+  // {
+  //   path: '/emails/:email_id/step01',
+  //   element: <Step01 />,
+  // },
+  // {
+  //   path: '/emails/:email_id/step02',
+  //   element: <Step02 />,
+  // },
+  // {
+  //   path: '/emails/:email_id/step03',
+  //   element: <Step03 />,
+  // },
+  // {
+  //   path: '/emails/:email_id/step04',
+  //   element: <Step04 />,
+  // },
 ]);
 
 export default router;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -62,50 +62,6 @@ const router = createBrowserRouter([
     path: '/sign-up',
     element: <SignUp />,
   },
-  // {
-  //   path: '/emails/:email_id',
-  //   element: <Step01 />,
-  // },
-  // {
-  //   path: '/emails',
-  //   element: <Emails />,
-  //   errorElement: <NotFound />,
-  //   children: [
-  //     {
-  //       index: true,
-  //       path: '/emails/:email_id/step01',
-  //       element: <Step01 />,
-  //     },
-  //     {
-  //       path: '/emails/:email_id/step02',
-  //       element: <Step02 />,
-  //     },
-  //     {
-  //       path: '/emails/:email_id/step03',
-  //       element: <Step03 />,
-  //     },
-  //     {
-  //       path: '/emails/:email_id/step04',
-  //       element: <Step04 />,
-  //     },
-  //   ],
-  // },
-  // {
-  //   path: '/emails/:email_id/step01',
-  //   element: <Step01 />,
-  // },
-  // {
-  //   path: '/emails/:email_id/step02',
-  //   element: <Step02 />,
-  // },
-  // {
-  //   path: '/emails/:email_id/step03',
-  //   element: <Step03 />,
-  // },
-  // {
-  //   path: '/emails/:email_id/step04',
-  //   element: <Step04 />,
-  // },
 ]);
 
 export default router;


### PR DESCRIPTION
### 주요구현사항
1. 이메일 생성에서 공통으로 쓰일 NAV추가
2. 이메일 생성 1단계 페이지 추가

### 기타사항
1. page안에 emails 디렉토리를 만들고 관련 페이지 components들을 옮겼습니다.
2. 공통 nav css props 공유는 2단계에서 작성 예정입니다.