### PR TITLE
feat: 발신자 설정 페이지 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run pre-commit
-npm run pre-commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run pre-commit
+npm run pre-commit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.3.0",
         "@fortawesome/free-regular-svg-icons": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/pages/Sender.jsx
+++ b/src/pages/Sender.jsx
@@ -1,5 +1,115 @@
 import React from 'react';
+import styled from 'styled-components';
 
 export default function Sender() {
-  return <div>발신자</div>;
+  const handleCodeButtonClick = () => {
+    console.log('코드 내보내기 버튼 클릭');
+  };
+
+  const handleModifyButtonClick = () => {
+    console.log('수정하기 버튼 클릭');
+  };
+
+  return (
+    <section>
+      <MainContainer>
+        <Title>발신자 설정</Title>
+        <ButtonContainer>
+          <CodeButton onClick={handleCodeButtonClick}>코드 내보내기</CodeButton>
+          <EditButton onClick={handleModifyButtonClick}>수정하기</EditButton>
+        </ButtonContainer>
+        <SenderInfoContainer>
+          <SenderNameTitle>발신자 이름</SenderNameTitle>
+          <SenderNameContent>김개똥</SenderNameContent>
+          <Spacer />
+          <EmailFooterTitle>이메일 푸터 정보</EmailFooterTitle>
+          <EmailFooterItemTitle>- 회사명 또는 이름</EmailFooterItemTitle>
+          <EmailFooterItemContent>바닐라코딩</EmailFooterItemContent>
+          <EmailFooterItemTitle>- 주소</EmailFooterItemTitle>
+          <EmailFooterItemContent>
+            서울 강남구 테헤란로 522 홍우빌딩 6층
+          </EmailFooterItemContent>
+          <EmailFooterItemTitle>- 전화번호</EmailFooterItemTitle>
+          <EmailFooterItemContent>02-6713-7279</EmailFooterItemContent>
+        </SenderInfoContainer>
+      </MainContainer>
+    </section>
+  );
 }
+
+const MainContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1000px;
+  height: 760px;
+  margin: auto;
+`;
+
+const Title = styled.span`
+  padding: 38px 0;
+  font-size: 1.75rem;
+  font-weight: 500;
+`;
+
+const ButtonContainer = styled.div`
+  padding-bottom: 10px;
+  text-align: end;
+`;
+
+const CodeButton = styled.button`
+  margin-right: 10px;
+  padding: 10px 14px;
+  border-radius: 5px;
+  background-color: #ffdf2b;
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+const EditButton = styled.button`
+  padding: 10px 14px;
+  border-radius: 5px;
+  background-color: #ffdf2b;
+  font-size: 0.875rem;
+  font-weight: 500;
+`;
+
+const SenderInfoContainer = styled.main`
+  display: grid;
+  grid-template-columns: 200px auto;
+  grid-template-rows: repeat(1fr, 6);
+  align-items: center;
+  width: 100%;
+  height: 296px;
+  padding: 30px;
+  border: 1px solid #bdbdbd;
+`;
+
+const SenderNameTitle = styled.div`
+  font-size: 1.125rem;
+  font-weight: 500;
+`;
+
+const SenderNameContent = styled.div`
+  font-size: 1rem;
+  font-weight: 400;
+`;
+
+const Spacer = styled.div`
+  grid-column: 1 / -1;
+`;
+
+const EmailFooterTitle = styled.div`
+  grid-column: 1 / -1;
+  font-size: 1.125rem;
+  font-weight: 500;
+`;
+
+const EmailFooterItemTitle = styled.div`
+  font-size: 1rem;
+  font-weight: 500;
+`;
+
+const EmailFooterItemContent = styled.div`
+  font-size: 0.875rem;
+  font-weight: 400;
+`;

--- a/src/pages/Sender.jsx
+++ b/src/pages/Sender.jsx
@@ -1,14 +1,87 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 export default function Sender() {
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [senderInfo, setSenderInfo] = useState({
+    userName: 'ken',
+    companyName: '바닐라코딩',
+    address: '서울 강남구 테헤란로 522 홍우빌딩 6층',
+    contact: '02-6713-7279',
+  });
+
   const handleCodeButtonClick = () => {
     console.log('코드 내보내기 버튼 클릭');
   };
 
   const handleModifyButtonClick = () => {
-    console.log('수정하기 버튼 클릭');
+    setIsEditMode(true);
   };
+
+  const handleSaveButtonClick = () => {
+    setIsEditMode(false);
+  };
+
+  const handleInputChange = e => {
+    const newSenderInfo = {
+      ...senderInfo,
+      [e.target.name]: e.target.value,
+    };
+
+    setSenderInfo(newSenderInfo);
+  };
+
+  if (isEditMode) {
+    return (
+      <section>
+        <MainContainer>
+          <Title>발신자 설정</Title>
+          <ButtonContainer>
+            <CodeButton onClick={handleCodeButtonClick}>
+              코드 내보내기
+            </CodeButton>
+            <SaveButton onClick={handleSaveButtonClick}>저장하기</SaveButton>
+          </ButtonContainer>
+          <SenderInfoContainer>
+            <SenderNameTitle>발신자 이름</SenderNameTitle>
+            <SenderNameInput
+              type="text"
+              id="userName"
+              name="userName"
+              value={senderInfo.userName}
+              onChange={handleInputChange}
+            />
+            <Spacer />
+            <EmailFooterTitle>이메일 푸터 정보</EmailFooterTitle>
+            <EmailFooterItemTitle>- 회사명 또는 이름</EmailFooterItemTitle>
+            <FooterInput
+              type="text"
+              id="companyName"
+              name="companyName"
+              value={senderInfo.companyName}
+              onChange={handleInputChange}
+            />
+            <EmailFooterItemTitle>- 주소</EmailFooterItemTitle>
+            <FooterInput
+              type="text"
+              id="address"
+              name="address"
+              value={senderInfo.address}
+              onChange={handleInputChange}
+            />
+            <EmailFooterItemTitle>- 전화번호</EmailFooterItemTitle>
+            <FooterInput
+              type="text"
+              id="contact"
+              name="contact"
+              value={senderInfo.contact}
+              onChange={handleInputChange}
+            />
+          </SenderInfoContainer>
+        </MainContainer>
+      </section>
+    );
+  }
 
   return (
     <section>
@@ -20,17 +93,17 @@ export default function Sender() {
         </ButtonContainer>
         <SenderInfoContainer>
           <SenderNameTitle>발신자 이름</SenderNameTitle>
-          <SenderNameContent>김개똥</SenderNameContent>
+          <SenderNameContent>{senderInfo.userName}</SenderNameContent>
           <Spacer />
           <EmailFooterTitle>이메일 푸터 정보</EmailFooterTitle>
           <EmailFooterItemTitle>- 회사명 또는 이름</EmailFooterItemTitle>
-          <EmailFooterItemContent>바닐라코딩</EmailFooterItemContent>
-          <EmailFooterItemTitle>- 주소</EmailFooterItemTitle>
           <EmailFooterItemContent>
-            서울 강남구 테헤란로 522 홍우빌딩 6층
+            {senderInfo.companyName}
           </EmailFooterItemContent>
+          <EmailFooterItemTitle>- 주소</EmailFooterItemTitle>
+          <EmailFooterItemContent>{senderInfo.address}</EmailFooterItemContent>
           <EmailFooterItemTitle>- 전화번호</EmailFooterItemTitle>
-          <EmailFooterItemContent>02-6713-7279</EmailFooterItemContent>
+          <EmailFooterItemContent>{senderInfo.contact}</EmailFooterItemContent>
         </SenderInfoContainer>
       </MainContainer>
     </section>
@@ -73,10 +146,19 @@ const EditButton = styled.button`
   font-weight: 500;
 `;
 
+const SaveButton = styled.button`
+  padding: 10px 14px;
+  border-radius: 5px;
+  background-color: black;
+  color: #ffdf2b;
+  font-size: 0.875rem;
+  font-weight: 500;
+`;
+
 const SenderInfoContainer = styled.main`
   display: grid;
   grid-template-columns: 200px auto;
-  grid-template-rows: repeat(1fr, 6);
+  grid-template-rows: 1fr 30px repeat(1fr, 4);
   align-items: center;
   width: 100%;
   height: 296px;
@@ -112,4 +194,21 @@ const EmailFooterItemTitle = styled.div`
 const EmailFooterItemContent = styled.div`
   font-size: 0.875rem;
   font-weight: 400;
+`;
+
+const SenderNameInput = styled.input`
+  position: relative;
+  left: -4px;
+  width: 50%;
+  height: 18px;
+  font-size: 1rem;
+`;
+
+const FooterInput = styled.input`
+  position: relative;
+  top: 1px;
+  left: -4px;
+  width: 50%;
+  height: 16px;
+  font-size: 0.875rem;
 `;

--- a/src/pages/emails/Emails.jsx
+++ b/src/pages/emails/Emails.jsx
@@ -161,7 +161,6 @@ const NewEmailButton = styled.button`
   background-color: #ffdf2b;
   font-size: 14px;
   font-weight: 500;
-  cursor: pointer;
 `;
 
 const ContentRow = styled.li`


### PR DESCRIPTION
## 변경사항
1. 발신자 설정 페이지를 추가했습니다.
2. 기존 목업의 동그라미 아이콘이 `-` 으로 대체되었습니다.
3. 수정하기를 누르면 발신자 정보 수정이 가능한 인풋이 나옵니다.

## 기타사항
1. 리액트쿼리와 리코일 도입전 메인 목업까지만 구현되어 있습니다.
2. 회의 때 말씀 드렸던 폰트만 rem 적용 완료 하였습니다.