### PR TITLE
feat: 발송 완료된 이메일 정보 화면 페이지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/pages/emails/EmailsDashboard.jsx
+++ b/src/pages/emails/EmailsDashboard.jsx
@@ -1,11 +1,92 @@
 import React from 'react';
 import styled from 'styled-components';
+import {
+  getKoreaDateString,
+  getOpenMailPercentage,
+  getSuccessPercentage,
+} from '../../utils/dashboard';
+
+// 임시 데이터
+const emailData = {
+  _id: '12315',
+  editingStep: 4,
+  emailTitle: '테스트 제목',
+  emailContent: '<h1>테스트 이메일 입니다<h1>',
+  sender: '홍길동',
+  emailPreviewText: '테스트 이메일 미리보기',
+  recipients: [
+    {
+      email: 'asdf@asdf.com',
+      name: '길홍동',
+      adAgreement: true,
+      isEmailOpen: false,
+    },
+    {
+      email: 'zxcv@asdf.com',
+      name: '홍길',
+      adAgreement: true,
+      isEmailOpen: true,
+    },
+    {
+      email: 'qwer@asdf.com',
+      name: '동길',
+      adAgreement: true,
+      isEmailOpen: true,
+    },
+  ],
+  totalSendCount: 3,
+  successSendCount: 3,
+  startSendDate: new Date(`2023/02/13`),
+  endSendDate: new Date('2023/02/14'),
+};
 
 export default function EmailsDashboard() {
+  const handleRecipientsButtonClick = () => {
+    console.log('수신자 목록 버튼 클릭');
+  };
+
   return (
     <section>
       <MainContainer>
         <Title>이메일 정보</Title>
+        <ButtonContainer>
+          <RecipientsButton onClick={handleRecipientsButtonClick}>
+            수신자 목록
+          </RecipientsButton>
+        </ButtonContainer>
+        <EmailInfoContainer>
+          <EmailInfoTitle>이메일 제목</EmailInfoTitle>
+          <EmailInfoContent>{emailData.emailTitle}</EmailInfoContent>
+          <EmailInfoTitle>이메일 URL</EmailInfoTitle>
+          <EmailInfoContent>https://ez-mail.com/ABCd</EmailInfoContent>
+          <EmailInfoTitle>발신자 이름</EmailInfoTitle>
+          <EmailInfoContent>{emailData.sender}</EmailInfoContent>
+          <EmailInfoTitle>발송시작일</EmailInfoTitle>
+          <EmailInfoContent>
+            {getKoreaDateString(emailData.startSendDate)}
+          </EmailInfoContent>
+          <EmailInfoTitle>발신자 이메일 주소</EmailInfoTitle>
+          <EmailInfoContent>abcd@abcd.com</EmailInfoContent>
+          <EmailInfoTitle>발송완료일</EmailInfoTitle>
+          <EmailInfoContent>
+            {getKoreaDateString(emailData.endSendDate)}
+          </EmailInfoContent>
+        </EmailInfoContainer>
+        <SmallTitle>발송정보</SmallTitle>
+        <PercentInfoBox>
+          <LeftPercentBox>
+            <PercentTitleText>발송성공</PercentTitleText>
+            <PercentNumberText>
+              {getSuccessPercentage(emailData)}
+            </PercentNumberText>
+          </LeftPercentBox>
+          <RightPercentBox>
+            <PercentTitleText>오픈</PercentTitleText>
+            <PercentNumberText inputColor="#ffdf2b">
+              {getOpenMailPercentage(emailData)}
+            </PercentNumberText>
+          </RightPercentBox>
+        </PercentInfoBox>
       </MainContainer>
     </section>
   );
@@ -23,4 +104,79 @@ const Title = styled.span`
   padding: 38px 0;
   font-size: 1.75rem;
   font-weight: 500;
+`;
+
+const ButtonContainer = styled.div`
+  padding-bottom: 10px;
+  text-align: end;
+`;
+
+const RecipientsButton = styled.button`
+  padding: 10px 14px;
+  border-radius: 5px;
+  background-color: #ffdf2b;
+  font-size: 0.875rem;
+  font-weight: 500;
+`;
+
+const EmailInfoContainer = styled.main`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  align-items: center;
+  width: 100%;
+  height: 296px;
+  margin-bottom: 50px;
+  padding: 30px;
+  border: 1px solid #bdbdbd;
+`;
+
+const EmailInfoTitle = styled.div`
+  color: #747579;
+  font-size: 1rem;
+  font-weight: 400;
+`;
+
+const EmailInfoContent = styled.div`
+  position: relative;
+  left: -50px;
+  font-size: 1rem;
+  font-weight: 400;
+`;
+
+const SmallTitle = styled.span`
+  padding-top: 20px;
+  padding-bottom: 32px;
+  font-size: 24px;
+  font-weight: 500;
+`;
+
+const PercentInfoBox = styled.div`
+  display: flex;
+  width: 450px;
+  height: 150px;
+  margin-bottom: 30px;
+`;
+
+const LeftPercentBox = styled.div`
+  width: 50%;
+  border: 1px solid #b5acac;
+`;
+
+const PercentTitleText = styled.div`
+  padding: 16px;
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+const PercentNumberText = styled.div`
+  padding-top: 4px;
+  color: ${props => props.inputColor || 'black'};
+  font-size: 50px;
+  text-align: center;
+`;
+
+const RightPercentBox = styled.div`
+  width: 50%;
+  border: 1px solid #b5acac;
+  border-width: 1px 1px 1px 0px;
 `;

--- a/src/pages/emails/EmailsDashboard.jsx
+++ b/src/pages/emails/EmailsDashboard.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export default function EmailsDashboard() {
+  return (
+    <section>
+      <MainContainer>
+        <Title>이메일 정보</Title>
+      </MainContainer>
+    </section>
+  );
+}
+
+const MainContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1000px;
+  height: 760px;
+  margin: auto;
+`;
+
+const Title = styled.span`
+  padding: 38px 0;
+  font-size: 1.75rem;
+  font-weight: 500;
+`;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -12,6 +12,7 @@ import Step02 from '../pages/emails/EmailEditingStep02';
 import Step03 from '../pages/emails/EmailEditingStep03';
 import Step04 from '../pages/emails/EmailEditingStep04';
 import Subscribers from '../pages/subscribers/Subscribers';
+import EmailsDashboard from '../pages/emails/EmailsDashboard';
 
 const router = createBrowserRouter([
   {
@@ -27,6 +28,10 @@ const router = createBrowserRouter([
       {
         path: '/emails',
         element: <Emails />,
+      },
+      {
+        path: '/emails/:email_id/dashboard',
+        element: <EmailsDashboard />,
       },
       {
         path: '/subscribers',

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -45,3 +45,11 @@ export function getOpenMailPercentage(data) {
 
   return `${Math.floor((openCount / totalCount) * 100)}%`;
 }
+
+export function getKoreaDateString(date) {
+  const koreaDate = new Date(
+    Date.parse(date) - date.getTimezoneOffset() * 60 * 1000,
+  );
+
+  return koreaDate.toLocaleString('ko-KR', { timeZone: 'UTC' });
+}


### PR DESCRIPTION
## 변경사항
1. 발송 완료된 이메일 정보 화면 페이지를 추가했습니다.
2. `utils/dashboard.js` 에 date 객체를 넣으면 한국시간 string 을 주는 함수를 추가했습니다.

## 건의사항
1. 이메일 URL 을 어떻게 구현해야 할지 고민입니다. 그냥 빼버려도 괜찮을 것 같습니다.
2. DB 의 이메일 탬플릿 정보에 발신자 이메일 주소를 추가해야 할 것 같습니다.