### PR TITLE
feat: 이메일 발송 완료 페이지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,10 @@ function App() {
   const location = useLocation();
   const params = useParams();
   if (location.pathname !== '/') {
-    if (location.pathname.includes(`/emails/${params.email_id}/step`)) {
+    if (
+      location.pathname !== `/emails/${params.email_id}/step04` &&
+      location.pathname.includes(`/emails/${params.email_id}/step`)
+    ) {
       return (
         <>
           <EmailEditingNav />

--- a/src/pages/emails/EmailEditingStep04.jsx
+++ b/src/pages/emails/EmailEditingStep04.jsx
@@ -1,5 +1,58 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+import logo from '../../assets/login-logo.png';
 
 export default function EmailEditingStep04() {
-  return <div>스텝4</div>;
+  const navigate = useNavigate();
+
+  const handleGoToMainButtonClick = () => {
+    navigate('/dashboard');
+  };
+
+  return (
+    <section>
+      <Container>
+        <Logo src={logo} alt="logo" />
+        <Description>
+          이메일 발송이 시작되었습니다.
+          <br />
+          발송결과는 이메일 정보 화면에서 확인해주세요.
+        </Description>
+        <Button onClick={handleGoToMainButtonClick}>메인으로 돌아가기</Button>
+      </Container>
+    </section>
+  );
 }
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 402px;
+  margin: auto;
+`;
+
+const Logo = styled.img`
+  width: 80px;
+  height: 80px;
+  margin-top: 170px;
+  margin-bottom: 40px;
+`;
+
+const Description = styled.span`
+  margin-bottom: 50px;
+  font-size: 1.25rem;
+  font-weight: 500;
+  text-align: center;
+`;
+
+const Button = styled.button`
+  width: 100%;
+  padding: 14px 0px 14px 0px;
+  border-radius: 5px;
+  background-color: #ffdf2b;
+  text-align: center;
+  font-weight: 500;
+`;


### PR DESCRIPTION
## 변경사항
1. 이메일 발송 완료 페이지를 `pages/emails/EmailEditingStep04.jsx` 에 추가했습니다
2. 해당 페이지는 메인 대쉬보드의 nav 를 공유하고있어서  app.jsx 에서 라우터 관련 로직을 수정했습니다.

## 건의사항
1. 예전에 말씀드린건 `emails/:email_id` 인 부모를 만들고 `emails/:email_id/step01 ~ 03` 을 자식들로 넣어 주는 라우터 세팅을 의미했던건데 정진님께서 짠 코드를 보니 모두 app 의 자식들로 들어가 있더라구요. 제가 코드리뷰할 때 미처 체크하지 못했네요. 리팩토링 시 한번 구조를 다시 고민해봐야 할 것 같습니다.