### PR TITLE
feat: cdn 코드 모달창 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/pages/CdnCodeModal.jsx
+++ b/src/pages/CdnCodeModal.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import Modal from '../components/Modal';
+
+const cdnData = `
+<link rel="stylesheet" href="https://s3.ap-northeast-2.amazonaws.com/resource.stibee.com/subscribe/stb_subscribe_form_style.css">
+<div id="stb_subscribe">
+  
+  <form action="https://stibee.com/api/v1.0/lists/hdLmF6VugnWfYX4J9AvLpINmxHJ3fw==/public/subscribers" method="POST" target="_blank" accept-charset="utf-8" class="stb_form" name="stb_subscribe_form" id="stb_subscribe_form" novalidate>
+    
+    <h1 class="stb_form_title">기본 주소록 구독하기</h1>
+    
+    
+      <fieldset class="stb_form_set">
+        <label for="stb_email" class="stb_form_set_label">
+          이메일 주소<span class="stb_asterisk">*</span>
+        </label>
+        <input type="text" class="stb_form_set_input" id="stb_email" name="email" required="required">
+        <div class="stb_form_msg_error" id="stb_email_error"></div>
+      </fieldset>
+    
+
+    
+
+    
+      <div class="stb_form_policy">
+        <label>
+          <input type="checkbox" id="stb_policy" value="stb_policy_true">
+          <span>(필수)</span>
+          <button id="stb_form_modal_open" data-modal="stb_form_policy_modal" class="stb_form_modal_open_btn" type="button">개인정보 수집 및 이용</button>에 동의합니다.
+        </label>
+        <div class="stb_form_msg_error" id="stb_policy_error"></div>
+        <div class="stb_form_modal stb_form_policy_text blind" id="stb_form_policy_modal">
+          <div class="stb_form_modal_body">
+            <h1 class="stb_form_modal_title">
+              개인정보 수집 및 이용
+            </h1>
+            <p class="stb_form_modal_text">뉴스레터 발송을 위한 최소한의 개인정보를 수집하고 이용합니다.
+수집된 정보는 발송 외 다른 목적으로 이용되지 않으며, 서비스가 종료되거나 구독을 해지할 경우 즉시 파기됩니다.</p>
+            <div class="stb_form_modal_btn">
+              <button id="stb_form_modal_close" class="stb_form_modal_close_btn" data-modal="stb_form_policy_modal" type="button">닫기</button>
+            </div>
+          </div>
+          <div class="stb_form_modal_bg" id="stb_form_modal_bg"></div>
+        </div>
+      </div>
+
+    
+    <div class="stb_form_result" id="stb_form_result">
+    </div>
+
+         
+      <fieldset class="stb_form_set_submit">
+        <button type="submit" class="stb_form_submit_button" id="stb_form_submit_button"
+          style="background-color: #FF6464; color: #FFFFFF;">구독하기</button>
+      </fieldset>
+    
+    </form>
+  </div>
+</div>
+<script type="text/javascript" src="https://s3.ap-northeast-2.amazonaws.com/resource.stibee.com/subscribe/stb_subscribe_form.js"></script>
+`;
+
+export default function CdnCodeModal() {
+  return (
+    <Modal title="아래 코드를 복사하여 홈페이지에 붙여넣으세요">
+      <CdnContainer>{cdnData}</CdnContainer>
+    </Modal>
+  );
+}
+
+const CdnContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 30px;
+  background-color: #333333;
+  color: white;
+  overflow-x: auto;
+  overflow-y: auto;
+`;

--- a/src/pages/CdnCodeModal.jsx
+++ b/src/pages/CdnCodeModal.jsx
@@ -71,11 +71,11 @@ export default function CdnCodeModal() {
 }
 
 const CdnContainer = styled.div`
+  overflow-x: auto;
+  overflow-y: auto;
   width: 100%;
   height: 100%;
   padding: 30px;
   background-color: #333333;
   color: white;
-  overflow-x: auto;
-  overflow-y: auto;
 `;

--- a/src/pages/Sender.jsx
+++ b/src/pages/Sender.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+
 import styled from 'styled-components';
 
 export default function Sender() {
@@ -9,9 +11,10 @@ export default function Sender() {
     address: '서울 강남구 테헤란로 522 홍우빌딩 6층',
     contact: '02-6713-7279',
   });
+  const navigate = useNavigate();
 
   const handleCodeButtonClick = () => {
-    console.log('코드 내보내기 버튼 클릭');
+    navigate('/sender/cdnCode');
   };
 
   const handleModifyButtonClick = () => {
@@ -106,6 +109,7 @@ export default function Sender() {
           <EmailFooterItemContent>{senderInfo.contact}</EmailFooterItemContent>
         </SenderInfoContainer>
       </MainContainer>
+      <Outlet />
     </section>
   );
 }

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -14,6 +14,7 @@ import Step04 from '../pages/emails/EmailEditingStep04';
 import Subscribers from '../pages/subscribers/Subscribers';
 import EmailsDashboard from '../pages/emails/EmailsDashboard';
 import EmailRecipientsModal from '../pages/emails/EmailRecipientsModal';
+import CdnCodeModal from '../pages/CdnCodeModal';
 
 const router = createBrowserRouter([
   {
@@ -47,6 +48,12 @@ const router = createBrowserRouter([
       {
         path: '/sender',
         element: <Sender />,
+        children: [
+          {
+            path: 'cdnCode',
+            element: <CdnCodeModal />,
+          },
+        ],
       },
       {
         path: '/emails/:email_id/step01',


### PR DESCRIPTION
## 변경사항
1. 발신자 설정에서 코드 내보내기 버튼을 누르면 코드 모달창이 뜨는 기능을 추가했습니다.
2. 수신자 모달창을 만들 때 만들어뒀던 모달 컴포넌트를 재사용 했습니다.

## 개선할 점들
1. 코드 복사 버튼을 만들어 주면 일일히 드래그해서 복사를 안해도 되서 ux가 좋아질 것 같습니다.
2. cdn 코드 데이터의 한줄 가로길이의 최대값을 정해놓으면 가로 스크롤이 없어져서 ui 적으로 좋아질 것 같습니다.