### PR TITLE
feat: 이메일 템플릿 리스트 리액트 쿼리 적용

### DIFF
--- a/src/api/email.js
+++ b/src/api/email.js
@@ -16,6 +16,34 @@ export async function fetchRecentEmail(userId) {
   return data;
 }
 
-export async function getEmails(userId) {
-  console.log(userId);
+export async function fetchEmails(userId) {
+  const FETCH_URL = `${config.serverOrigin}/users/${userId}/email-templates`;
+  const options = {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  };
+
+  const res = await fetch(FETCH_URL, options);
+  const data = await res.json();
+
+  return data;
+}
+
+export async function fetchCreateEmail(userId) {
+  const FETCH_URL = `${config.serverOrigin}/users/${userId}/email-templates`;
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  };
+
+  const res = await fetch(FETCH_URL, options);
+  const data = await res.json();
+
+  return data;
 }

--- a/src/api/subscriber.js
+++ b/src/api/subscriber.js
@@ -15,3 +15,19 @@ export async function fetchSubscriberTrend(userId) {
 
   return data;
 }
+
+export async function fetchSubscribers(userId) {
+  const FETCH_URL = `${config.serverOrigin}/users/${userId}/subscribers`;
+  const options = {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  };
+
+  const res = await fetch(FETCH_URL, options);
+  const data = await res.json();
+
+  return data;
+}

--- a/src/pages/emails/Emails.jsx
+++ b/src/pages/emails/Emails.jsx
@@ -20,8 +20,8 @@ export default function Emails() {
   const navigate = useNavigate();
   const userId = useRecoilValue(userIdAtom);
   const {
-    isLoading: getLoading,
-    error: getError,
+    isLoading,
+    error,
     data: emailTemplatesData,
   } = useQuery({
     queryKey: ['userEmailTemplates', userId],
@@ -32,11 +32,11 @@ export default function Emails() {
     },
   });
 
-  if (getLoading) {
+  if (isLoading) {
     return <Loading />;
   }
 
-  if (getError) {
+  if (error) {
     return <Error>error</Error>;
   }
 

--- a/src/pages/emails/Emails.jsx
+++ b/src/pages/emails/Emails.jsx
@@ -8,54 +8,37 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { faCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
 
-const emailTemplatesData = [
-  {
-    _id: '12315',
-    editingStep: 1,
-    emailTitle: '이메일 테스트1',
-    updatedAt: '2023. 02. 14 오후 2:00',
-  },
-  {
-    _id: '12316',
-    editingStep: '04',
-    emailTitle: '이메일 테스트2',
-    updatedAt: '2023. 02. 14 오후 2:00',
-  },
-  {
-    _id: '12317',
-    editingStep: '01',
-    emailTitle: '이메일 테스트3',
-    updatedAt: '2023. 02. 14 오후 2:00',
-  },
-  {
-    _id: '12318',
-    editingStep: '01',
-    emailTitle: '이메일 테스트4',
-    updatedAt: '2023. 02. 11 오후 2:00',
-  },
-  {
-    _id: '12319',
-    editingStep: '03',
-    emailTitle: '이메일 테스트6',
-    updatedAt: '2023. 01. 11 오후 2:00',
-  },
-  {
-    _id: '12320',
-    editingStep: '03',
-    emailTitle: '이메일 테스트4',
-    updatedAt: '2023. 02. 11 오후 2:00',
-  },
-  {
-    _id: '12321',
-    editingStep: '04',
-    emailTitle: '이메일 테스트4',
-    updatedAt: '2023. 02. 01 오후 1:00',
-  },
-];
+import { fetchEmails } from '../../api/email';
+import Loading from '../../components/Loading';
+import Error from '../../components/Error';
+import userIdAtom from '../../recoil/userId/atom';
 
 export default function Emails() {
   const navigate = useNavigate();
+  const userId = useRecoilValue(userIdAtom);
+  const {
+    isLoading: getLoading,
+    error: getError,
+    data: emailTemplatesData,
+  } = useQuery({
+    queryKey: ['userEmailTemplates', userId],
+    queryFn: async () => {
+      const data = await fetchEmails(userId);
+
+      return data;
+    },
+  });
+
+  if (getLoading) {
+    return <Loading />;
+  }
+
+  if (getError) {
+    return <Error>error</Error>;
+  }
 
   const handleNewEmailButtonClick = () => {
     console.log('이메일 생성 api 실행');
@@ -70,11 +53,11 @@ export default function Emails() {
   };
 
   const handleDeleteButtonClick = () => {
-    console.log('삭제 버튼 클릭');
+    console.log('삭제 버튼 클릭 -> 삭제 api 요청 후 재조회');
   };
 
   const handleEditButtonClick = () => {
-    console.log('수정 버튼 클릭');
+    console.log('수정 버튼 클릭 -> 해당 step으로 가야함');
   };
 
   const emailTemplatesList = emailTemplatesData


### PR DESCRIPTION
### <변경사항>
1. 이메일 리스트 리코일&리액트 쿼리 적용했습니다.
### <보완할점>
1. 이메일 리스트가 없을때 화면이 약간 휑하네요. 일단은 큰문제는 없어보입니다. 나중에 추가하면 될것같아요
2. 이메일 생성까지 해보려다가 잘 안되어서 일단 조회만 추가하고 푸시했습니다. 내일 적용해보겠습니다.
3. 구독자 리스트 조회도 api 적용을 시도했는데 구독자 리스트를 조회해서 state에 바로 꽂아버리는 과정에서 에러가 나는데 정확한 원인을 못찾았습니다. 이것도 내일 해결해보겠습니다.
4. 이메일 템플릿 삭제 API가 없습니다. (이메일 리스트 화면에서 삭제가능) 이것도 추가해야겠습니다.