### PR TITLE
feat: 발송 완료 이메일 상세페이지 리액트 쿼리 적용 & 자잘한 코드 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.19.1",
+  "version": "0.19.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/api/email.js
+++ b/src/api/email.js
@@ -16,6 +16,22 @@ export async function fetchRecentEmail(userId) {
   return data;
 }
 
+export async function fetchEmail(userId, emailId) {
+  const FETCH_URL = `${config.serverOrigin}/users/${userId}/email-templates/${emailId}`;
+  const options = {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  };
+
+  const res = await fetch(FETCH_URL, options);
+  const data = await res.json();
+
+  return data;
+}
+
 export async function fetchEmails(userId) {
   const FETCH_URL = `${config.serverOrigin}/users/${userId}/email-templates`;
   const options = {

--- a/src/components/RecentEmailPercent.jsx
+++ b/src/components/RecentEmailPercent.jsx
@@ -3,17 +3,18 @@ import { useRecoilValue } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 
-import Loading from './Loading';
 import userIdAtom from '../recoil/userId/atom';
 import { fetchRecentEmail } from '../api/email';
 import {
   getOpenMailPercentage,
   getSuccessPercentage,
 } from '../utils/dashboard';
+import Loading from './Loading';
 import Error from './Error';
 
 export default function RecentEmailPercent() {
   const userId = useRecoilValue(userIdAtom);
+
   const {
     isLoading,
     error,

--- a/src/pages/Sender.jsx
+++ b/src/pages/Sender.jsx
@@ -14,7 +14,6 @@ export default function Sender() {
   const userId = useRecoilValue(userIdAtom);
   const [isEditMode, setIsEditMode] = useState(false);
   const [updateCount, setUpdateCount] = useState(0);
-  const [userCdnCode, setUserCdnCode] = useState('');
   const [senderInfo, setSenderInfo] = useState({
     userName: '',
     companyName: '',
@@ -22,17 +21,16 @@ export default function Sender() {
     contact: '',
   });
 
-  const { isLoading, error } = useQuery({
+  const { isLoading, error, data } = useQuery({
     queryKey: ['senderData', userId, updateCount],
     queryFn: async () => {
       const result = await fetchSendingInfo(userId);
 
       return result;
     },
-    onSuccess: data => {
-      const { userName, companyName, address, contact, cdnCode } = data;
+    onSuccess: senderInfoData => {
+      const { userName, companyName, address, contact } = senderInfoData;
 
-      setUserCdnCode(cdnCode);
       setSenderInfo({
         userName,
         companyName,
@@ -53,7 +51,7 @@ export default function Sender() {
   const handleCodeButtonClick = () => {
     navigate('/sender/cdnCode', {
       state: {
-        userCdnCode,
+        userCdnCode: data.cdnCode,
       },
     });
   };

--- a/src/pages/emails/EmailRecipientsModal.jsx
+++ b/src/pages/emails/EmailRecipientsModal.jsx
@@ -1,73 +1,13 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Modal from '../../components/Modal';
 
-const recipientsData = [
-  {
-    _id: '12315',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: true,
-  },
-  {
-    _id: '123151',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: true,
-  },
-  {
-    _id: '123152',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: false,
-  },
-  {
-    _id: '123153',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: false,
-  },
-  {
-    _id: '123154',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: false,
-  },
-  {
-    _id: '123155',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: false,
-  },
-  {
-    _id: '123156',
-    email: 'abcd112asdf342345@teasdfst.com',
-    name: '김개똥',
-    adAgreement: false,
-  },
-  {
-    _id: '123157',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: true,
-  },
-  {
-    _id: '123158',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: false,
-  },
-  {
-    _id: '123159',
-    email: 'abcd@test.com',
-    name: '김개똥',
-    adAgreement: false,
-  },
-];
-
 export default function EmailRecipientsModal() {
-  const recipients = recipientsData.map(recipient => {
+  const location = useLocation();
+
+  const recipients = location.state.recipients.map(recipient => {
     return (
       <Li key={recipient._id}>
         <EmailData>{recipient.email}</EmailData>
@@ -138,6 +78,7 @@ const Li = styled.li`
 const EmailData = styled.span`
   word-wrap: break-word;
   width: 170px;
+  padding: 4px;
   font-size: 0.875rem;
   font-weight: 400;
 `;

--- a/src/pages/emails/EmailsDashboard.jsx
+++ b/src/pages/emails/EmailsDashboard.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
-import { fetchEmail } from '../../api/email';
 
+import { fetchEmail } from '../../api/email';
 import userIdAtom from '../../recoil/userId/atom';
 import {
   getKoreaDateString,

--- a/src/pages/emails/EmailsDashboard.jsx
+++ b/src/pages/emails/EmailsDashboard.jsx
@@ -1,53 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
+import { fetchEmail } from '../../api/email';
 
+import userIdAtom from '../../recoil/userId/atom';
 import {
   getKoreaDateString,
   getOpenMailPercentage,
   getSuccessPercentage,
 } from '../../utils/dashboard';
-
-// 임시 데이터
-const emailData = {
-  _id: '12315',
-  editingStep: 4,
-  emailTitle: '테스트 제목',
-  emailContent: '<h1>테스트 이메일 입니다<h1>',
-  sender: '홍길동',
-  emailPreviewText: '테스트 이메일 미리보기',
-  recipients: [
-    {
-      email: 'asdf@asdf.com',
-      name: '길홍동',
-      adAgreement: true,
-      isEmailOpen: false,
-    },
-    {
-      email: 'zxcv@asdf.com',
-      name: '홍길',
-      adAgreement: true,
-      isEmailOpen: true,
-    },
-    {
-      email: 'qwer@asdf.com',
-      name: '동길',
-      adAgreement: true,
-      isEmailOpen: true,
-    },
-  ],
-  totalSendCount: 3,
-  successSendCount: 3,
-  startSendDate: new Date(`2023/02/13`),
-  endSendDate: new Date('2023/02/14'),
-};
+import Loading from '../../components/Loading';
+import Error from '../../components/Error';
 
 export default function EmailsDashboard() {
   const navigate = useNavigate();
   const params = useParams();
+  const userId = useRecoilValue(userIdAtom);
+
+  const {
+    isLoading,
+    error,
+    data: emailData,
+  } = useQuery({
+    queryKey: ['emailDashboard', userId, params.email_id],
+    queryFn: async () => {
+      const result = await fetchEmail(userId, params.email_id);
+
+      return result;
+    },
+  });
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (error) {
+    return <Error>error</Error>;
+  }
 
   const handleRecipientsButtonClick = () => {
-    navigate(`/emails/${params.email_id}/dashboard/recipients`);
+    navigate(`/emails/${params.email_id}/dashboard/recipients`, {
+      state: {
+        recipients: emailData.recipients,
+      },
+    });
   };
 
   return (

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -50,7 +50,7 @@ export function getOpenMailPercentage(data) {
 
 export function getKoreaDateString(date) {
   const koreaDate = new Date(
-    Date.parse(date) - date.getTimezoneOffset() * 60 * 1000,
+    Date.parse(date) - new Date(date).getTimezoneOffset() * 60 * 1000,
   );
 
   return koreaDate.toLocaleString('ko-KR', { timeZone: 'UTC' });


### PR DESCRIPTION
## 변경사항
1. 발송 완료 이메일 상세페이지에 리액트 쿼리를 적용했습니다.
2. 발송 완료 이메일 수신자 리스트 모달창에 리액트 쿼리를 적용했습니다.
3. 기존 발신자 설정에서 cdnCode 를 state 에 보관하고 있는게 useState 남용이라 판단해 삭제했습니다.
4. 컴포넌트 import 코드가 떨어져있던 부분들을 수정했습니다.
5. date 객체를 한국 시간으로 변경해주는 유틸함수가 서버에서 받아온 데이터에 올바르게 대응하지 못하여 수정했습니다.

## 보완할 점들
1. 로딩, 에러 컴포넌트가 페이지 별로 뜨는 위치가 다릅니다. 주요 기능들이 다 구현되고 나면 개선해야 할 것 같습니다.