### PR TITLE
feat: 드래그 드랍 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.24.1",
+  "version": "0.24.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/components/emailEditingStep03/BoxTool.jsx
+++ b/src/components/emailEditingStep03/BoxTool.jsx
@@ -16,6 +16,7 @@ import {
 export default function BoxTool() {
   const onDragStart = (e, type) => {
     let contentType = null;
+
     switch (type) {
       case 'image':
         contentType = {

--- a/src/components/emailEditingStep03/BoxTool.jsx
+++ b/src/components/emailEditingStep03/BoxTool.jsx
@@ -19,7 +19,7 @@ export default function BoxTool() {
     switch (type) {
       case 'image':
         contentType = {
-          id: String(Math.random()),
+          id: crypto.randomUUID(),
           isActive: false,
           isDraggable: false,
           type: 'image',
@@ -44,7 +44,7 @@ export default function BoxTool() {
         break;
       case 'spacer':
         contentType = {
-          id: String(Math.random()),
+          id: crypto.randomUUID(),
           isActive: false,
           isDraggable: false,
           type: 'spacer',
@@ -59,7 +59,7 @@ export default function BoxTool() {
         break;
       case 'divider':
         contentType = {
-          id: String(Math.random()),
+          id: crypto.randomUUID(),
           isActive: false,
           isDraggable: false,
           type: 'divider',
@@ -83,7 +83,7 @@ export default function BoxTool() {
         break;
       case 'button':
         contentType = {
-          id: String(Math.random()),
+          id: crypto.randomUUID(),
           isActive: false,
           isDraggable: false,
           type: 'button',

--- a/src/components/emailEditingStep03/BoxTool.jsx
+++ b/src/components/emailEditingStep03/BoxTool.jsx
@@ -14,33 +14,137 @@ import {
 } from '@fortawesome/free-regular-svg-icons';
 
 export default function BoxTool() {
+  const onDragStart = (e, type) => {
+    let contentType = null;
+    switch (type) {
+      case 'image':
+        contentType = {
+          id: String(Math.random()),
+          isActive: false,
+          isDraggable: false,
+          type: 'image',
+          link: 'https://beta.reactjs.org/',
+          imageSrc:
+            'https://images.unsplash.com/photo-1504194104404-433180773017?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80',
+          boxStyle: {
+            backgroundColor: 'yellow',
+            borderWidth: '0px',
+            borderColor: 'black',
+            borderStyle: 'solid',
+            paddingTop: '15px',
+            paddingBottom: '15px',
+            paddingLeft: '5px',
+            paddingRight: '5px',
+            textAlign: 'center',
+          },
+          contentStyle: {
+            width: '400px',
+          },
+        };
+        break;
+      case 'spacer':
+        contentType = {
+          id: String(Math.random()),
+          isActive: false,
+          isDraggable: false,
+          type: 'spacer',
+          boxStyle: {
+            backgroundColor: 'green',
+            borderWidth: '1px',
+            borderColor: 'black',
+            borderStyle: 'solid',
+            height: '50px',
+          },
+        };
+        break;
+      case 'divider':
+        contentType = {
+          id: String(Math.random()),
+          isActive: false,
+          isDraggable: false,
+          type: 'divider',
+          boxStyle: {
+            backgroundColor: 'yellow',
+            borderWidth: '0px',
+            borderColor: 'black',
+            borderStyle: 'solid',
+            paddingTop: '15px',
+            paddingBottom: '15px',
+            paddingLeft: '10px',
+            paddingRight: '10px',
+          },
+          contentStyle: {
+            height: '1px',
+            borderTopWidth: '3px',
+            borderTopColor: 'black',
+            borderTopStyle: 'solid',
+          },
+        };
+        break;
+      case 'button':
+        contentType = {
+          id: String(Math.random()),
+          isActive: false,
+          isDraggable: false,
+          type: 'button',
+          link: 'https://beta.reactjs.org/',
+          content: '길지 버튼',
+          boxStyle: {
+            backgroundColor: 'orange',
+            borderWidth: '1px',
+            borderColor: 'black',
+            borderStyle: 'solid',
+            paddingTop: '15px',
+            paddingBottom: '15px',
+            paddingLeft: '15px',
+            paddingRight: '15px',
+            textAlign: 'center',
+          },
+          contentStyle: {
+            backgroundColor: '#ffdf2b',
+            borderWidth: '0px',
+            borderColor: 'black',
+            borderStyle: 'solid',
+            borderRadius: '3px',
+            color: 'white',
+            fontSize: '16px',
+            fontFamily:
+              'AppleSDGothic, "apple sd gothic neo", "noto sans korean", "noto sans korean regular", "noto sans cjk kr", "noto sans cjk", "nanum gothic", "malgun gothic", dotum, arial, helvetica, sans-serif',
+          },
+        };
+        break;
+      default:
+        console.log('해당타입이 없습니다.');
+    }
+    e.dataTransfer.setData('content', JSON.stringify(contentType));
+  };
   return (
     <ToolBoxContainer>
-      <ToolBox draggable="true">
+      <ToolBox draggable="true" onDragStart={e => onDragStart(e, 'text')}>
         <StyledIcon icon={faAlignLeft} />
         <ToolBoxText>텍스트</ToolBoxText>
       </ToolBox>
-      <ToolBox draggable="true">
+      <ToolBox draggable="true" onDragStart={e => onDragStart(e, 'image')}>
         <StyledIcon icon={faImage} />
         <ToolBoxText>이미지</ToolBoxText>
       </ToolBox>
-      <ToolBox draggable="true">
+      <ToolBox draggable="true" onDragStart={e => onDragStart(e, 'button')}>
         <StyledIcon icon={faHandPointer} />
         <ToolBoxText>버튼</ToolBoxText>
       </ToolBox>
-      <ToolBox draggable="true">
+      <ToolBox draggable="true" onDragStart={e => onDragStart(e, 'video')}>
         <StyledIcon icon={faVideo} />
         <ToolBoxText>비디오</ToolBoxText>
       </ToolBox>
-      <ToolBox draggable="true">
+      <ToolBox draggable="true" onDragStart={e => onDragStart(e, 'spacer')}>
         <StyledIcon icon={faSquareFull} />
         <ToolBoxText>공백</ToolBoxText>
       </ToolBox>
-      <ToolBox draggable="true">
+      <ToolBox draggable="true" onDragStart={e => onDragStart(e, 'footer')}>
         <StyledIcon icon={faXmarksLines} />
         <ToolBoxText>푸터</ToolBoxText>
       </ToolBox>
-      <ToolBox draggable="true">
+      <ToolBox draggable="true" onDragStart={e => onDragStart(e, 'divider')}>
         <StyledIcon icon={faWindowMinimize} />
         <ToolBoxText>구분선</ToolBoxText>
       </ToolBox>

--- a/src/components/emailEditingStep03/ContentMovePanel.jsx
+++ b/src/components/emailEditingStep03/ContentMovePanel.jsx
@@ -7,19 +7,10 @@ import {
   faTrashCan,
 } from '@fortawesome/free-solid-svg-icons';
 
-export default function ContentMovePanel({
-  onDraggable,
-  onUnDraggable,
-  onDelete,
-  onCopy,
-}) {
+export default function ContentMovePanel({ onDraggable, onDelete, onCopy }) {
   return (
     <ControlBox draggable={false}>
-      <StyledIcon
-        icon={faArrowsUpDownLeftRight}
-        onMouseDown={onDraggable}
-        onMouseUp={onUnDraggable}
-      />
+      <StyledIcon icon={faArrowsUpDownLeftRight} onMouseDown={onDraggable} />
       <StyledIcon icon={faClone} onClick={onCopy} />
       <StyledIcon icon={faTrashCan} onClick={onDelete} />
     </ControlBox>

--- a/src/components/emailEditingStep03/ContentMovePanel.jsx
+++ b/src/components/emailEditingStep03/ContentMovePanel.jsx
@@ -5,25 +5,52 @@ import {
   faArrowsUpDownLeftRight,
   faClone,
   faTrashCan,
-} from '@fortawesome/free-regular-svg-icons';
+} from '@fortawesome/free-solid-svg-icons';
 
-export default function ContentMovePanel() {
+export default function ContentMovePanel({
+  onDraggable,
+  onUnDraggable,
+  onDelete,
+  onCopy,
+}) {
   return (
-    <ControlBox>
-      <FontAwesomeIcon icon={faArrowsUpDownLeftRight} />
-      <FontAwesomeIcon icon={faClone} />
-      <StyledIcon icon={faTrashCan} />
+    <ControlBox draggable={false}>
+      <StyledIcon
+        icon={faArrowsUpDownLeftRight}
+        onMouseDown={onDraggable}
+        onMouseUp={onUnDraggable}
+      />
+      <StyledIcon icon={faClone} onClick={onCopy} />
+      <StyledIcon icon={faTrashCan} onClick={onDelete} />
     </ControlBox>
   );
 }
 
 const ControlBox = styled.div`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  top: 0;
+  right: -60px;
   width: 50px;
-  height: 150px;
-  background-color: white;
+  padding: 5px 10px;
+  background-color: #ffffff;
+  gap: 8px;
 `;
 
 const StyledIcon = styled(FontAwesomeIcon)`
-  font-size: 1.5rem;
-  color: #f44336;
+  font-size: 1.1rem;
+  &:hover {
+    background-color: #f5f5f5;
+  }
+  &:nth-child(1) {
+    cursor: grab;
+  }
+  &:nth-child(2) {
+    cursor: pointer;
+  }
+  &:nth-child(3) {
+    cursor: pointer;
+    color: #f44336;
+  }
 `;

--- a/src/components/emailEditingStep03/contentWrapper.jsx
+++ b/src/components/emailEditingStep03/contentWrapper.jsx
@@ -9,6 +9,7 @@ export default function ContentWrapper({
   onDragEnter,
   onDragOver,
   onDragLeave,
+  onDragEnd,
   onDrop,
   onFocus,
   onBlur,
@@ -22,6 +23,7 @@ export default function ContentWrapper({
       onDragStart={onDragStart}
       onDragEnter={onDragEnter}
       onDragOver={onDragOver}
+      onDragEnd={onDragEnd}
       onDragLeave={onDragLeave}
       onDrop={onDrop}
       onFocus={onFocus}

--- a/src/components/emailEditingStep03/contentWrapper.jsx
+++ b/src/components/emailEditingStep03/contentWrapper.jsx
@@ -1,13 +1,40 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export default function ContentWrapper({ id, children }) {
-  return <Wrapper key={id}>{children}</Wrapper>;
+export default function ContentWrapper({
+  id,
+  children,
+  isDraggable,
+  onDragStart,
+  onDragEnter,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onFocus,
+  onBlur,
+}) {
+  return (
+    <Wrapper
+      key={id}
+      id={id}
+      tabIndex={0}
+      draggable={isDraggable}
+      onDragStart={onDragStart}
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onFocus={onFocus}
+      onBlur={onBlur}
+    >
+      {children}
+    </Wrapper>
+  );
 }
 
 const Wrapper = styled.div`
   width: 100%;
-
+  position: relative;
   &:hover {
     z-index: 1;
     outline: 2px solid #ffdf2b;

--- a/src/pages/emails/EmailEditingStep03.jsx
+++ b/src/pages/emails/EmailEditingStep03.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
+
+import { addProperties, removeProperties } from '../../utils/dragAndDrop';
 import LeftNav from '../../components/emailEditingStep03/LeftNav';
 import TextContent from '../../components/emailEditingStep03/TextContent';
 import ContentMovePanel from '../../components/emailEditingStep03/ContentMovePanel';
@@ -20,8 +22,6 @@ const emailTemplateData = {
   emailContents: [
     {
       id: 'asdf1',
-      isActive: false,
-      isDraggable: false,
       type: 'spacer',
       boxStyle: {
         backgroundColor: 'green',
@@ -33,8 +33,6 @@ const emailTemplateData = {
     },
     {
       id: 'asdf2',
-      isActive: false,
-      isDraggable: false,
       type: 'divider',
       boxStyle: {
         backgroundColor: 'yellow',
@@ -55,8 +53,6 @@ const emailTemplateData = {
     },
     {
       id: 'asdf3',
-      isActive: false,
-      isDraggable: false,
       type: 'image',
       link: 'https://beta.reactjs.org/',
       imageSrc:
@@ -78,8 +74,6 @@ const emailTemplateData = {
     },
     {
       id: 'asdf4',
-      isActive: false,
-      isDraggable: false,
       type: 'spacer',
       boxStyle: {
         height: '20px',
@@ -91,8 +85,6 @@ const emailTemplateData = {
     },
     {
       id: 'asdf5',
-      isActive: false,
-      isDraggable: false,
       type: 'button',
       link: 'https://beta.reactjs.org/',
       content: '길지 버튼',
@@ -124,13 +116,13 @@ const emailTemplateData = {
 
 export default function EmailEditingStep03() {
   const [emailContentsData, setEmailContentsData] = useState([]);
-  const dragItem = useRef();
-  const dragOverItem = useRef();
-  const dragItemIndex = useRef();
-  const dragOverItemIndex = useRef();
+  const $dragItem = useRef();
+  const $dragOverItem = useRef();
+  const $dragItemIndex = useRef();
+  const $dragOverItemIndex = useRef();
 
   useEffect(() => {
-    setEmailContentsData(emailTemplateData.emailContents);
+    setEmailContentsData(addProperties(emailTemplateData.emailContents));
   }, []);
 
   const handleDraggable = e => {
@@ -139,8 +131,10 @@ export default function EmailEditingStep03() {
       if (item.id === targetId) {
         return { ...item, isDraggable: true };
       }
+
       return item;
     });
+
     setEmailContentsData(newEmailContents);
   };
 
@@ -149,6 +143,7 @@ export default function EmailEditingStep03() {
       if (item.id === e.target.id) {
         return { ...item, isActive: true };
       }
+
       return item;
     });
 
@@ -164,8 +159,8 @@ export default function EmailEditingStep03() {
   };
 
   const handleDragStart = (e, index) => {
-    dragItemIndex.current = index;
-    dragItem.current = e.currentTarget;
+    $dragItemIndex.current = index;
+    $dragItem.current = e.currentTarget;
     e.dataTransfer.effectAllowed = 'move';
     const img = new Image();
 
@@ -173,8 +168,8 @@ export default function EmailEditingStep03() {
   };
 
   const handleDragEnter = (e, index) => {
-    dragOverItemIndex.current = index;
-    dragOverItem.current = e.currentTarget;
+    $dragOverItemIndex.current = index;
+    $dragOverItem.current = e.currentTarget;
   };
 
   const handleDragEnd = e => {
@@ -191,17 +186,17 @@ export default function EmailEditingStep03() {
     const contentHeight = e.currentTarget.offsetHeight / 2;
     const middleOfContent = rect.top + contentHeight;
     const absolute = Math.abs(
-      dragItemIndex.current - dragOverItemIndex.current,
+      $dragItemIndex.current - $dragOverItemIndex.current,
     );
 
     if (e.dataTransfer.effectAllowed === 'move') {
       if (
         (absolute === 1 &&
           e.clientY > middleOfContent &&
-          dragItemIndex.current > dragOverItemIndex.current) ||
+          $dragItemIndex.current > $dragOverItemIndex.current) ||
         (absolute === 1 &&
           e.clientY < middleOfContent &&
-          dragItemIndex.current < dragOverItemIndex.current)
+          $dragItemIndex.current < $dragOverItemIndex.current)
       ) {
         // 의미없는 이동 시도
         return;
@@ -209,35 +204,35 @@ export default function EmailEditingStep03() {
 
       if (
         e.clientY < middleOfContent &&
-        dragItemIndex.current < dragOverItemIndex.current &&
+        $dragItemIndex.current < $dragOverItemIndex.current &&
         absolute > 1
       ) {
         // 위에서 아래로 2칸이상 이동, 컨텐츠 위쪽으로 넣을때
         const draggedItem = newEmailContents.splice(
-          dragItemIndex.current,
+          $dragItemIndex.current,
           1,
         )[0];
 
-        newEmailContents.splice(dragOverItemIndex.current - 1, 0, draggedItem);
+        newEmailContents.splice($dragOverItemIndex.current - 1, 0, draggedItem);
       } else if (
         e.clientY > middleOfContent &&
-        dragItemIndex.current > dragOverItemIndex.current &&
+        $dragItemIndex.current > $dragOverItemIndex.current &&
         absolute > 1
       ) {
         // 아래에서 위로 2칸이상 이동, 컨텐츠 아래쪽으로 넣을때
         const draggedItem = newEmailContents.splice(
-          dragItemIndex.current,
+          $dragItemIndex.current,
           1,
         )[0];
 
-        newEmailContents.splice(dragOverItemIndex.current + 1, 0, draggedItem);
+        newEmailContents.splice($dragOverItemIndex.current + 1, 0, draggedItem);
       } else {
         const draggedItem = newEmailContents.splice(
-          dragItemIndex.current,
+          $dragItemIndex.current,
           1,
         )[0];
 
-        newEmailContents.splice(dragOverItemIndex.current, 0, draggedItem);
+        newEmailContents.splice($dragOverItemIndex.current, 0, draggedItem);
       }
     } else {
       const newContent = JSON.parse(e.dataTransfer.getData('content'));
@@ -249,9 +244,9 @@ export default function EmailEditingStep03() {
       }
     }
 
-    dragItemIndex.current = null;
-    dragOverItemIndex.current = null;
-    dragOverItem.current.style.boxShadow = 'none';
+    $dragItemIndex.current = null;
+    $dragOverItemIndex.current = null;
+    $dragOverItem.current.style.boxShadow = 'none';
 
     setEmailContentsData(newEmailContents);
   };
@@ -264,9 +259,9 @@ export default function EmailEditingStep03() {
     const middleOfContent = rect.top + contentHeight;
 
     if (e.clientY > middleOfContent) {
-      dragOverItem.current.style.boxShadow = '0 2px red';
+      $dragOverItem.current.style.boxShadow = '0 2px red';
     } else {
-      dragOverItem.current.style.boxShadow = '0 -2px red';
+      $dragOverItem.current.style.boxShadow = '0 -2px red';
     }
   };
 

--- a/src/pages/emails/EmailEditingStep03.jsx
+++ b/src/pages/emails/EmailEditingStep03.jsx
@@ -116,10 +116,10 @@ const emailTemplateData = {
 
 export default function EmailEditingStep03() {
   const [emailContentsData, setEmailContentsData] = useState([]);
-  const $dragItem = useRef();
-  const $dragOverItem = useRef();
-  const $dragItemIndex = useRef();
-  const $dragOverItemIndex = useRef();
+  const $dragItemRef = useRef();
+  const $dragOverItemRef = useRef();
+  const $dragItemIndexRef = useRef();
+  const $dragOverItemIndexRef = useRef();
 
   useEffect(() => {
     setEmailContentsData(addProperties(emailTemplateData.emailContents));
@@ -159,8 +159,8 @@ export default function EmailEditingStep03() {
   };
 
   const handleDragStart = (e, index) => {
-    $dragItemIndex.current = index;
-    $dragItem.current = e.currentTarget;
+    $dragItemIndexRef.current = index;
+    $dragItemRef.current = e.currentTarget;
     e.dataTransfer.effectAllowed = 'move';
     const img = new Image();
 
@@ -168,8 +168,8 @@ export default function EmailEditingStep03() {
   };
 
   const handleDragEnter = (e, index) => {
-    $dragOverItemIndex.current = index;
-    $dragOverItem.current = e.currentTarget;
+    $dragOverItemIndexRef.current = index;
+    $dragOverItemRef.current = e.currentTarget;
   };
 
   const handleDragEnd = e => {
@@ -186,17 +186,17 @@ export default function EmailEditingStep03() {
     const contentHeight = e.currentTarget.offsetHeight / 2;
     const middleOfContent = rect.top + contentHeight;
     const absolute = Math.abs(
-      $dragItemIndex.current - $dragOverItemIndex.current,
+      $dragItemIndexRef.current - $dragOverItemIndexRef.current,
     );
 
     if (e.dataTransfer.effectAllowed === 'move') {
       if (
         (absolute === 1 &&
           e.clientY > middleOfContent &&
-          $dragItemIndex.current > $dragOverItemIndex.current) ||
+          $dragItemIndexRef.current > $dragOverItemIndexRef.current) ||
         (absolute === 1 &&
           e.clientY < middleOfContent &&
-          $dragItemIndex.current < $dragOverItemIndex.current)
+          $dragItemIndexRef.current < $dragOverItemIndexRef.current)
       ) {
         // 의미없는 이동 시도
         return;
@@ -204,35 +204,43 @@ export default function EmailEditingStep03() {
 
       if (
         e.clientY < middleOfContent &&
-        $dragItemIndex.current < $dragOverItemIndex.current &&
+        $dragItemIndexRef.current < $dragOverItemIndexRef.current &&
         absolute > 1
       ) {
         // 위에서 아래로 2칸이상 이동, 컨텐츠 위쪽으로 넣을때
         const draggedItem = newEmailContents.splice(
-          $dragItemIndex.current,
+          $dragItemIndexRef.current,
           1,
         )[0];
 
-        newEmailContents.splice($dragOverItemIndex.current - 1, 0, draggedItem);
+        newEmailContents.splice(
+          $dragOverItemIndexRef.current - 1,
+          0,
+          draggedItem,
+        );
       } else if (
         e.clientY > middleOfContent &&
-        $dragItemIndex.current > $dragOverItemIndex.current &&
+        $dragItemIndexRef.current > $dragOverItemIndexRef.current &&
         absolute > 1
       ) {
         // 아래에서 위로 2칸이상 이동, 컨텐츠 아래쪽으로 넣을때
         const draggedItem = newEmailContents.splice(
-          $dragItemIndex.current,
+          $dragItemIndexRef.current,
           1,
         )[0];
 
-        newEmailContents.splice($dragOverItemIndex.current + 1, 0, draggedItem);
+        newEmailContents.splice(
+          $dragOverItemIndexRef.current + 1,
+          0,
+          draggedItem,
+        );
       } else {
         const draggedItem = newEmailContents.splice(
-          $dragItemIndex.current,
+          $dragItemIndexRef.current,
           1,
         )[0];
 
-        newEmailContents.splice($dragOverItemIndex.current, 0, draggedItem);
+        newEmailContents.splice($dragOverItemIndexRef.current, 0, draggedItem);
       }
     } else {
       const newContent = JSON.parse(e.dataTransfer.getData('content'));
@@ -244,9 +252,9 @@ export default function EmailEditingStep03() {
       }
     }
 
-    $dragItemIndex.current = null;
-    $dragOverItemIndex.current = null;
-    $dragOverItem.current.style.boxShadow = 'none';
+    $dragItemIndexRef.current = null;
+    $dragOverItemIndexRef.current = null;
+    $dragOverItemRef.current.style.boxShadow = 'none';
 
     setEmailContentsData(newEmailContents);
   };
@@ -259,9 +267,9 @@ export default function EmailEditingStep03() {
     const middleOfContent = rect.top + contentHeight;
 
     if (e.clientY > middleOfContent) {
-      $dragOverItem.current.style.boxShadow = '0 2px red';
+      $dragOverItemRef.current.style.boxShadow = '0 2px red';
     } else {
-      $dragOverItem.current.style.boxShadow = '0 -2px red';
+      $dragOverItemRef.current.style.boxShadow = '0 -2px red';
     }
   };
 

--- a/src/utils/dragAndDrop.js
+++ b/src/utils/dragAndDrop.js
@@ -6,3 +6,35 @@ export function setImageUrl(file, setState) {
     setState(e.target.result);
   };
 }
+
+export function addProperties(list) {
+  const addedList = list.map(item => {
+    if (
+      !Object.prototype.hasOwnProperty.call(item, 'isActive') ||
+      !Object.prototype.hasOwnProperty.call(item, 'isDraggable')
+    ) {
+      return Object.assign(item, { isActive: false }, { isDraggable: false });
+    }
+
+    return item;
+  });
+
+  return addedList;
+}
+
+export function removeProperties(list) {
+  const removedList = list.map(item => {
+    if (
+      Object.prototype.hasOwnProperty.call(item, 'isActive') &&
+      Object.prototype.hasOwnProperty.call(item, 'isDraggable')
+    ) {
+      const { isActive, isDraggable, ...newItem } = item;
+
+      return newItem;
+    }
+
+    return item;
+  });
+
+  return removedList;
+}


### PR DESCRIPTION
### 구현사항
1. 작업대 내의 컨텐츠 드래그&드랍 이동, 복사, 삭제
2. 이미지, 버튼, 공백, 구분선 박스에 대한 드래그&드랍 추가

### 참고사항
컨텐츠 추가시 uuid값은 math.random으로 임시처리했습니다.
useEffect로 최초 emailTemplateData state 임시처리했습니다.

### 개선사항
자잘한 버그들이 있습니다. 차차 수정해보겠습니다.
1. 버튼 컴포넌트 클릭시 포커스가 간헐적으로 작동안함
4. 내가 원하는 곳에 boxshadow가 제대로 안생기는 경우가 있음 -> 아래로 옮길때만 발생함
5. 드래그 후 컨텐츠박스자체가 draggable 상태가 됨. 

사용해보시면서 버그 발견하면 제보해주세요

### 추가 커밋사항
- 내가 원하는 곳에 boxshadow가 제대로 안생기는 경우가 있음 -> 아래로 옮길때만 발생함
해당 버그는 boxshadow 문제가 아니라 drag&drop 전반적인 로직 자체가 문제가 있었습니다. 
drag drop 로직을 완전히 개편하여서 원하는 위치에 잘 들어가는거 확인했습니다.
다만 boxShadow는 아직 문제가있는데 이부분은 브라우저상에서 style을 확인해보면 style이 입혀져있는데 보이지는 않습니다.
로직문제가 아닌 다른문제가 있는것같은데 원인을 찾기 힘들어서 우선 푸시합니다. 도움 요청드립니다.
- 드래그 후 컨텐츠박스자체가 draggable 상태가 됨. 
개선하였습니다.
- 컨텐츠 추가시 uuid값은 math.random으로 임시처리했습니다.
crypto.randomUUID로 처리했습니다.