### PR TITLE
feat: 이메일 데이터를 html 로 바꿔주는 유틸함수 추가 및 이메일 탬플릿 기본값 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/GlobalStyles.js
+++ b/src/GlobalStyles.js
@@ -37,6 +37,18 @@ const GlobalStyles = createGlobalStyle`
     font-size: 16px;
   }
 
+  i {
+    font-style: italic;
+  }
+
+  b {
+    font-weight: 700;
+  }
+
+  u {
+    text-decoration: underline;
+  }
+
   ol, ul {
     list-style: none;
   }

--- a/src/components/emailEditingStep03/BoxTool.jsx
+++ b/src/components/emailEditingStep03/BoxTool.jsx
@@ -109,6 +109,7 @@ export default function BoxTool() {
             borderStyle: 'solid', // 사용자 조절값 X, 스타일 유지를 위한 고정값
             borderRadius: '3px', // 버튼 모양 기본값 사각형, 원형: 500px
             fontSize: '16px', // 글자 크기 기본값 16px, 12, 14, 18, 20, 26, 32, 40, 48, 60
+            textDecoration: 'none', // 사용자 조절값 X
             fontFamily:
               'AppleSDGothic, "apple sd gothic neo", "noto sans korean", "noto sans korean regular", "noto sans cjk kr", "noto sans cjk", "nanum gothic", "malgun gothic", dotum, arial, helvetica, sans-serif',
           },

--- a/src/pages/emails/EmailEditingStep03.jsx
+++ b/src/pages/emails/EmailEditingStep03.jsx
@@ -14,10 +14,12 @@ import ContentStyleTool from '../../components/emailEditingStep03/ContentStyleTo
 const emailTemplateData = {
   emailBodyStyle: { backgroundColor: '#f5f5f5' },
   emailContainerStyle: {
-    backgroundColor: 'white',
+    backgroundColor: '#FFFFFF',
     borderWidth: '0px',
-    borderColor: 'black',
+    borderColor: '#000000',
     borderStyle: 'solid',
+    fontFamily:
+      'AppleSDGothic, "apple sd gothic neo", "noto sans korean", "noto sans korean regular", "noto sans cjk kr", "noto sans cjk", "nanum gothic", "malgun gothic", dotum, arial, helvetica, sans-serif',
   },
   emailFooter: {
     companyOrUserName: '바닐라코딩',
@@ -37,9 +39,9 @@ const emailTemplateData = {
       id: 'asdf1',
       type: 'spacer',
       boxStyle: {
-        backgroundColor: 'green',
+        backgroundColor: '#2DD500',
         borderWidth: '1px',
-        borderColor: 'black',
+        borderColor: '#000000',
         borderStyle: 'solid',
         height: '50px',
       },
@@ -48,9 +50,9 @@ const emailTemplateData = {
       id: 'asdf2',
       type: 'divider',
       boxStyle: {
-        backgroundColor: 'yellow',
+        backgroundColor: '#FFEC00',
         borderWidth: '0px',
-        borderColor: 'black',
+        borderColor: '#000000',
         borderStyle: 'solid',
         paddingTop: '15px',
         paddingBottom: '15px',
@@ -60,7 +62,7 @@ const emailTemplateData = {
       contentStyle: {
         height: '1px',
         borderTopWidth: '3px',
-        borderTopColor: 'black',
+        borderTopColor: '#000000',
         borderTopStyle: 'solid',
       },
     },
@@ -71,7 +73,7 @@ const emailTemplateData = {
       imageSrc:
         'https://images.unsplash.com/photo-1504194104404-433180773017?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80',
       boxStyle: {
-        backgroundColor: 'yellow',
+        backgroundColor: '#FFEC00',
         borderWidth: '0px',
         borderColor: 'black',
         borderStyle: 'solid',
@@ -91,16 +93,17 @@ const emailTemplateData = {
       type: 'spacer',
       boxStyle: {
         height: '20px',
-        backgroundColor: 'transparent',
+        backgroundColor: '#ffffff',
         borderWidth: '0px',
-        borderColor: 'black',
+        borderColor: '#000000',
         borderStyle: 'solid',
       },
     },
     {
       id: 'text123',
       type: 'text',
-      content: '뿡빵뿡빵 <div style="font-size: 18px">키득</div>',
+      content:
+        '텍스트 에디터<div><br></div><div><b>이것은</b> <del>가로줄</del> <i>테스트</i> <u>글자</u></div>',
       boxStyle: {
         paddingTop: '15px',
         paddingBottom: '15px',
@@ -120,9 +123,9 @@ const emailTemplateData = {
       link: 'https://beta.reactjs.org/',
       content: '길지 버튼',
       boxStyle: {
-        backgroundColor: 'orange',
+        backgroundColor: '#FFA600',
         borderWidth: '1px',
-        borderColor: 'black',
+        borderColor: '#000000',
         borderStyle: 'solid',
         paddingTop: '15px',
         paddingBottom: '15px',
@@ -134,12 +137,13 @@ const emailTemplateData = {
         display: 'inline-block',
         backgroundColor: '#ffdf2b',
         borderWidth: '0px',
-        borderColor: 'black',
+        borderColor: '#000000',
         borderStyle: 'solid',
         borderRadius: '3px',
         padding: '16px 18px',
         color: '#000000',
         fontSize: '16px',
+        textDecoration: 'none',
         fontFamily:
           'AppleSDGothic, "apple sd gothic neo", "noto sans korean", "noto sans korean regular", "noto sans cjk kr", "noto sans cjk", "nanum gothic", "malgun gothic", dotum, arial, helvetica, sans-serif',
       },

--- a/src/utils/emailEditing.jsx
+++ b/src/utils/emailEditing.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+import ReactDOMServer from 'react-dom/server';
 
 import ButtonContent from '../components/emailEditingStep03/ButtonContent';
 import DividerContent from '../components/emailEditingStep03/DividerContent';
@@ -48,7 +49,124 @@ export function dataToComponent(data) {
   }
 }
 
-export function dataToEmailTemplate(data) {
+function dataToEmailComponent(data) {
+  switch (data.type) {
+    case 'spacer':
+      return (
+        <tr>
+          <td align="center" valign="top">
+            <table
+              border="0"
+              cellPadding="0"
+              cellSpacing="0"
+              width="100%"
+              style={data.boxStyle}
+            />
+          </td>
+        </tr>
+      );
+    case 'divider':
+      return (
+        <tr>
+          <td align="center" valign="top">
+            <table
+              border="0"
+              cellPadding="0"
+              cellSpacing="0"
+              width="100%"
+              style={data.boxStyle}
+            >
+              <tr>
+                <td align="center" valign="top" style={data.contentStyle} />
+              </tr>
+            </table>
+          </td>
+        </tr>
+      );
+    case 'image':
+      return (
+        <tr>
+          <td align="center" valign="top">
+            <table
+              border="0"
+              cellPadding="0"
+              cellSpacing="0"
+              width="100%"
+              style={data.boxStyle}
+            >
+              <tr>
+                <td valign="top">
+                  <a href={data.link}>
+                    <img
+                      alt="userImg"
+                      src={data.imageSrc}
+                      style={data.contentStyle}
+                    />
+                  </a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      );
+    case 'button':
+      return (
+        <tr>
+          <td align="center" valign="top">
+            <table
+              border="0"
+              cellPadding="0"
+              cellSpacing="0"
+              width="100%"
+              style={data.boxStyle}
+            >
+              <tr>
+                <td valign="top">
+                  <a href={data.link} style={data.contentStyle}>
+                    {data.content}
+                  </a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      );
+    case 'text':
+      return (
+        <tr>
+          <td align="center" valign="top">
+            <table
+              border="0"
+              cellPadding="0"
+              cellSpacing="0"
+              width="100%"
+              style={data.boxStyle}
+            >
+              <tr>
+                <td
+                  valign="top"
+                  style={data.contentStyle}
+                  dangerouslySetInnerHTML={{ __html: data.content }}
+                />
+              </tr>
+            </table>
+          </td>
+        </tr>
+      );
+    default:
+      console.log('해당 타입이 없습니다.');
+  }
+}
+
+function dataToEmailTemplate(emailTemplateData) {
+  const contents = emailTemplateData.emailContents.map(contentData => {
+    return (
+      <Fragment key={contentData.id}>
+        {dataToEmailComponent(contentData)}
+      </Fragment>
+    );
+  });
+
   return (
     <table
       border="0"
@@ -57,6 +175,7 @@ export function dataToEmailTemplate(data) {
       height="100%"
       width="100%"
       id="bodyTable"
+      style={emailTemplateData.emailBodyStyle}
     >
       <tr>
         <td align="center" valign="top">
@@ -66,41 +185,9 @@ export function dataToEmailTemplate(data) {
             cellSpacing="0"
             width="600"
             id="emailContainer"
+            style={emailTemplateData.emailContainerStyle}
           >
-            <tr>
-              <td align="center" valign="top">
-                <table
-                  border="0"
-                  cellPadding="0"
-                  cellSpacing="0"
-                  width="100%"
-                  id="emailHeader"
-                >
-                  <tr>
-                    <td align="center" valign="top">
-                      This is where my header content goes.
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td align="center" valign="top">
-                <table
-                  border="0"
-                  cellPadding="0"
-                  cellSpacing="0"
-                  width="100%"
-                  id="emailBody"
-                >
-                  <tr>
-                    <td align="center" valign="top">
-                      This is where my body content goes.
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
+            {contents}
             <tr>
               <td align="center" valign="top">
                 <table
@@ -111,8 +198,16 @@ export function dataToEmailTemplate(data) {
                   id="emailFooter"
                 >
                   <tr>
-                    <td align="center" valign="top">
-                      This is where my footer content goes.
+                    <td
+                      align="center"
+                      valign="top"
+                      style={emailTemplateData.emailFooter.boxStyle}
+                    >
+                      <div>
+                        {emailTemplateData.emailFooter.companyOrUserName}
+                      </div>
+                      <div>{emailTemplateData.emailFooter.contact}</div>
+                      <div>{emailTemplateData.emailFooter.address}</div>
                     </td>
                   </tr>
                 </table>
@@ -123,4 +218,12 @@ export function dataToEmailTemplate(data) {
       </tr>
     </table>
   );
+}
+
+export function getEmailHtml(data) {
+  const emailHtml = ReactDOMServer.renderToStaticMarkup(
+    dataToEmailTemplate(data),
+  );
+
+  return emailHtml;
 }


### PR DESCRIPTION
## 변경사항
1. 이메일 데이터를 html 로 만들어주는 유틸함수를 추가했습니다.
2. 이메일 탬플릿의 버튼컨텐츠 기본값에 a태그 밑줄 부분이 안나오도록 수정했습니다.
3. 목데이터 값들을 색상코드를 헥사코드로 수정했습니다.
4. 전체 스타일에 영향을 미치는 스타일 태그들 `i`, `b`, `u`, `del` 이 적용되도록 기본 설정 스타일을 수정했습니다.