### PR TITLE
fix: 스페이스 컨텐츠 replace 관련 에러 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.29.6",
+  "version": "0.29.7",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/components/emailEditingStep03/StyleControlPanels/SpacerContainer.jsx
+++ b/src/components/emailEditingStep03/StyleControlPanels/SpacerContainer.jsx
@@ -83,10 +83,9 @@ export default function SpacerContainer({ index }) {
           min="10"
           max="100"
           step="10"
-          value={emailContentsData.emailContents[index].boxStyle.height.replace(
-            'px',
-            '',
-          )}
+          value={emailContentsData.emailContents[
+            index
+          ].boxStyle.height?.replace('px', '')}
           onChange={handleInputChange}
         />
         <p>{emailContentsData.emailContents[index].boxStyle.height}</p>


### PR DESCRIPTION
## 변경사항
1. 다른 type 상자의 데이터 값이 space 컨트롤 패널에 들어와 앱이 아예 멈추는 치명적 버그가 있었는데 일단 옵셔널 체이닝 연산자를 사용하여 해결함. 다른 값이 들어온다면 상자 컨트롤 패널에 높이가 px 글자가 붙지 않게 됐는데 어차피 다른 상자를 누르면 상자 컨트롤 패널을 보여줄 필요가 없어 시연에 무리가 없음.

## 개선이 필요한 사항
1. 버그를 고치며 느낀건데 정진님이 작성하셨던 controle panels 들의 파일 이름이 어색함 수정 필요해 보임.
2. 컨트롤 패널에 데이터가 들어오는 근본적인 플로우에서 차단하는게 더 좋을 듯 함.