### PR TITLE
fix: 드래그드랍 boxshadow버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.29.7",
+  "version": "0.29.8",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/pages/emails/EmailEditingStep03.jsx
+++ b/src/pages/emails/EmailEditingStep03.jsx
@@ -151,6 +151,8 @@ export default function EmailEditingStep03() {
 
   const handleDrop = (e, index) => {
     if (e.target.tagName === 'IMG' || e.dataTransfer.effectAllowed === 'all') {
+      $dragOverItemRef.current.style.boxShadow = 'none';
+
       return;
     }
 


### PR DESCRIPTION
이미지가 업로드된 박스에 상자컴포넌트를 드래그드랍시 남아있던 boxshadow를 제거했습니다.