### PR TITLE
fix: 작업대 요소 드래그시 이미지 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/pages/emails/EmailEditingStep03.jsx
+++ b/src/pages/emails/EmailEditingStep03.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
@@ -34,11 +34,10 @@ export default function EmailEditingStep03() {
   const [focusedIndex, setFocusedIndex] = useState('');
   const dragImageRef = useRef(null);
 
-  useEffect(() => {
-    const img = new Image();
-    img.src = draglogo;
-    dragImageRef.current = img;
-  }, []);
+  const img = new Image();
+
+  img.src = draglogo;
+  dragImageRef.current = img;
 
   const { data: senderData } = useQuery({
     queryKey: ['senderData', userId],

--- a/src/pages/emails/EmailEditingStep03.jsx
+++ b/src/pages/emails/EmailEditingStep03.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
@@ -32,6 +32,13 @@ export default function EmailEditingStep03() {
   const $dragOverItemIndexRef = useRef();
   const [focusedType, setFocusedType] = useState(null);
   const [focusedIndex, setFocusedIndex] = useState('');
+  const dragImageRef = useRef(null);
+
+  useEffect(() => {
+    const img = new Image();
+    img.src = draglogo;
+    dragImageRef.current = img;
+  }, []);
 
   const { data: senderData } = useQuery({
     queryKey: ['senderData', userId],
@@ -129,12 +136,10 @@ export default function EmailEditingStep03() {
     $dragItemIndexRef.current = index;
     $dragItemRef.current = e.currentTarget;
     e.dataTransfer.effectAllowed = 'move';
-    const img = new Image();
-    img.src = draglogo;
 
     setFocusedType(null);
 
-    e.dataTransfer.setDragImage(img, 0, 0);
+    e.dataTransfer.setDragImage(dragImageRef.current, 20, 20);
   };
 
   const handleDragEnter = (e, index) => {


### PR DESCRIPTION
1. 드래그시 이미지를 추가하여 테스트중 이미지가 간헐적으로 보였다 안보였다 하는 현상을 발견하여 해당 버그 수정하였습니다.
드래그시 이미지를 받아오지못하는게 원인으로 보여서 useEffect를 활용해 image를 preload하여 해당 현상을 없앴습니다. -> useEffect 제거했습니다.
2. 드래그시작시 보여지는 이미지 위치를 수정하였습니다.